### PR TITLE
adds functions to translate form and event names from exported data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.idea
 .phpunit.result.cache
+ignore/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /.idea
 .phpunit.result.cache
-ignore/
+/ignore/
+/vendor/
+composer*

--- a/APISyncExternalModule.php
+++ b/APISyncExternalModule.php
@@ -1156,8 +1156,8 @@ class APISyncExternalModule extends \ExternalModules\AbstractExternalModule{
 			return "Couldn't open the uploaded file.";
 		}
 		
-		if (empty($translation_matrix)) {
-			"Couldn't parse uploaded CSV file into a valid, non-empty translation matrix.";
+		if (empty($translation_matrix) or $csv_field_count < 2) {
+			"Couldn't parse uploaded CSV file into a valid translation matrix.";
 		}
 		
 		// save translations to appropriate setting key/index

--- a/APISyncExternalModule.php
+++ b/APISyncExternalModule.php
@@ -984,12 +984,14 @@ class APISyncExternalModule extends \ExternalModules\AbstractExternalModule{
 		
 		foreach (['form', 'event'] as $type) {
 			$setting = &$project[$proj_key_prefix . "$type-translations"];
-			if (!empty($setting)) {
+			if (!empty($setting) and gettype($setting) == 'string') {
 				$setting = json_decode($setting, true);
-				foreach($setting as $i => $row) {
-					foreach($row as $j => $name) {
-						$func_name = "format" . ucfirst($type) . "Name";
-						$setting[$i][$j] = $this->$func_name($name);
+				if ($setting) {
+					foreach($setting as $i => $row) {
+						foreach($row as $j => $name) {
+							$func_name = "format" . ucfirst($type) . "Name";
+							$setting[$i][$j] = $this->$func_name($name);
+						}
 					}
 				}
 			}

--- a/APISyncExternalModule.php
+++ b/APISyncExternalModule.php
@@ -636,6 +636,7 @@ class APISyncExternalModule extends \ExternalModules\AbstractExternalModule{
 		$this->translateFormNames($data, $project);
 		$this->translateEventNames($data, $project);
 		
+		$proj_key_prefix = $this->getProjectTypePrefix($project);
 		$prefix = $project[$proj_key_prefix . 'record-id-prefix'];
 		$metadata = $this->getMetadata($this->getProjectId());
 		$formNamesByField = [];

--- a/APISyncExternalModule.php
+++ b/APISyncExternalModule.php
@@ -981,22 +981,21 @@ class APISyncExternalModule extends \ExternalModules\AbstractExternalModule{
 	
 	public function buildTranslations(&$project) {
 		// function will only build translations if json present in $project['form-translations'/'event-translations']
+		if ($this->translationsAreBuilt($project)) {
+			return;
+		}
 		$proj_key_prefix = $this->getProjectTypePrefix($project);
 		
 		foreach (['form', 'event'] as $type) {
 			$setting = &$project[$proj_key_prefix . "$type-translations"];
-			if (!empty($setting) and gettype($setting) == 'string') {
-				$setting = json_decode($setting, true);
-				if ($setting) {
-					foreach($setting as $i => $row) {
-						foreach($row as $j => $name) {
-							$func_name = "format" . ucfirst($type) . "Name";
-							$setting[$i][$j] = $this->$func_name($name);
-						}
+			$setting = json_decode($setting, true);
+			if ($setting) {
+				foreach($setting as $i => $row) {
+					foreach($row as $j => $name) {
+						$func_name = "format" . ucfirst($type) . "Name";
+						$setting[$i][$j] = $this->$func_name($name);
 					}
 				}
-			} else {
-				unset($project[$proj_key_prefix . "$type-translations"]);
 			}
 		}
 	}

--- a/APISyncExternalModule.php
+++ b/APISyncExternalModule.php
@@ -632,8 +632,6 @@ class APISyncExternalModule extends \ExternalModules\AbstractExternalModule{
 		if (gettype($project['event-translations']) == 'array') {
 			$this->translateEventNames($response, $project['event-translations']);
 		}
-		
-		// carl_log('data after translations applied: ' . print_r($response, true));
 
 		$this->prepareImportData($response, $recordIdFieldName, $project['record-id-prefix']);
 
@@ -1027,8 +1025,6 @@ class APISyncExternalModule extends \ExternalModules\AbstractExternalModule{
 				}
 			}
 		}
-		
-		// carl_log("translations built, \$project: " . print_r($project, true));
 	}
 	
 	private function getEdocInfo($doc_id) {
@@ -1123,11 +1119,9 @@ class APISyncExternalModule extends \ExternalModules\AbstractExternalModule{
 	}
 
 	public function importTranslationsTable() {
-		carl_log("calling importTranslationsTable");
 		// this function returns null (when successful) or a string error message
 		$validation = $this->validateImport();
 		if (gettype($validation) == 'string') {
-			carl_log("validation: " . print_r($validation, true));
 			return $validation;
 		}
 		
@@ -1139,7 +1133,6 @@ class APISyncExternalModule extends \ExternalModules\AbstractExternalModule{
 		foreach(preg_split("/((\r?\n)|(\r\n?))/", $translations) as $line){
 			$translation_matrix[] = str_getcsv(db_escape($line));
 		}
-		carl_log("importTranslationsTable translation_matrix: " . print_r($translation_matrix, true));
 		
 		// save translations to appropriate setting key/index
 		$this->saveTranslations($translation_matrix, $validation['target_server_index'], $validation['target_project_index']);

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
 	"name": "API Sync",
 	"namespace": "Vanderbilt\\APISyncExternalModule",
-	"framework-version": 2,
+	"framework-version": 5,
 	"description": "Automates exporting/importing to/from remote REDCap servers via the API.  The Data Dictionaries for the local and remote projects are expected to be either identical or compatible.  This module could easily be expanded to support additional scenarios (like automatically syncing the data dictionary as well).",
 	"authors": [
 		{
@@ -93,6 +93,18 @@
 							"key": "export-record-id-prefix",
 							"name": "<div style='max-width: 350px; display: inline-block; vertical-align: top;'><b>Record ID Prefix</b> - Optional, but highly recommend if data is coming into the destination project from other sources.  This prefix will be prepended to all exported records ids to ensure that they're unique on the destination.</div>",
 							"type": "text"
+						},
+						{
+							"key": "export-form-translations",
+							"name": "JSON matrix containing form name tranlsations. To specify translations, visit the 'Configure Translations' module page in the project sidebar",
+							"type": "text",
+							"hidden": true
+						},
+						{
+							"key": "export-event-translations",
+							"name": "JSON matrix containing event name tranlsations. To specify translations, visit the 'Configure Translations' module page in the project sidebar",
+							"type": "text",
+							"hidden": true
 						}
 					]
 				}
@@ -152,13 +164,15 @@
 						},
 						{
 							"key": "form-translations",
-							"name": "Upload form translations file",
-							"type": "file"
+							"name": "JSON matrix containing form name tranlsations. To specify translations, visit the 'Configure Translations' module page in the project sidebar",
+							"type": "text",
+							"hidden": true
 						},
 						{
 							"key": "event-translations",
-							"name": "Upload event translations file",
-							"type": "file"
+							"name": "JSON matrix containing event name tranlsations. To specify translations, visit the 'Configure Translations' module page in the project sidebar",
+							"type": "text",
+							"hidden": true
 						}
 					]
 				}
@@ -171,6 +185,12 @@
 				"name": "API Sync",
 				"icon": "databases_arrow",
 				"url": "api-sync.php",
+				"show-header-and-footer": true
+			},
+			{
+				"name": "Configure Translations",
+				"icon": "databases_arrow",
+				"url": "config_translations.php",
 				"show-header-and-footer": true
 			}
 		]

--- a/config.json
+++ b/config.json
@@ -149,6 +149,16 @@
 							"key": "import-batch-size",
 							"name": "Import Batch Size (optional)",
 							"type": "text"
+						},
+						{
+							"key": "form-translations",
+							"name": "Upload form translations file",
+							"type": "file"
+						},
+						{
+							"key": "event-translations",
+							"name": "Upload event translations file",
+							"type": "file"
 						}
 					]
 				}

--- a/config.json
+++ b/config.json
@@ -191,7 +191,7 @@
 				"name": "Configure Translations",
 				"icon": "databases_arrow",
 				"url": "config_translations.php",
-				"show-header-and-footer": true
+				"show-header-and-footer": false
 			}
 		]
 	},

--- a/config_translations.php
+++ b/config_translations.php
@@ -93,16 +93,52 @@ function printProjectCard($project_info) {
 	<?php
 }
 
-foreach ([$export_servers, $import_servers] as $server_set) {
-	foreach ($server_set as $server_i => $server) {
-		$url = $server['redcap-url'];
-		foreach ($server['projects'] as $project_i => $project) {
-			$project['url'] = $url;
-			$project['server-index'] = $server_i + 1;
-			$project['server-type'] = $server_set == $import_servers ? 'import' : 'export';
-			$project['project-index'] = $project_i + 1;
-			printProjectCard($project);
+if (empty($import_servers) and empty($export_servers)) {
+	?>
+	<div class='alert alert-primary w-50'>
+		<h5 class='py-2'>No export/import servers configured</h5>
+		<p>Once you visit the External Modules page and configure servers and projects to export/import to or from, you can return to this page to specify form and event translations.</p>
+	</div>
+	<?php
+} else {
+	?>
+	<div class='alert alert-primary w-75'>
+		<h5 class=''>Form and Event Translations</h5>
+		<p>You can edit the tables below to specify form and event translations per project.</p>
+		<p>For each table, the first column should hold the name of forms and events that exist on this project.</p>
+		<p>For import tables, columns past the first column should hold the names of forms or events that you want the API Sync module to translate upon import. Each value will be translated to the name in the first column.</p>
+		<p>For export tables, the API Sync module converts this project's form and event names in the first column to the value in the second column upon export.</p>
+	</div>
+	<?php
+}
+
+foreach ($import_servers as $server_i => $server) {
+	$url = $server['redcap-url'];
+	foreach ($server['projects'] as $project_i => $project) {
+		$project['url'] = $url;
+		$project['server-index'] = $server_i + 1;
+		$project['server-type'] = 'import';
+		$project['project-index'] = $project_i + 1;
+		if (empty($url) or empty($project['api-key'])) {
+			continue;
 		}
+		printProjectCard($project);
+	}
+}
+
+// show export server projects
+foreach ($export_servers as $server_i => $server) {
+	$url = $server['export-redcap-url'];
+	foreach ($server['export-projects'] as $project_i => $project) {
+		$project['url'] = $url;
+		$project['server-index'] = $server_i + 1;
+		$project['server-type'] = 'export';
+		$project['project-index'] = $project_i + 1;
+		$project['api-key'] = $project['export-api-key'];
+		if (empty($url) or empty($project['api-key'])) {
+			continue;
+		}
+		printProjectCard($project);
 	}
 }
 

--- a/config_translations.php
+++ b/config_translations.php
@@ -60,7 +60,7 @@ function printProjectCard($project_info) {
 		<div class='table-controls ml-3'>
 			<button type='button' class='btn btn-outline-primary btn-sm'>+ Row</button>
 			<button type='button' class='btn btn-outline-primary btn-sm'>+ Column</button>
-			<button type='button' class='btn btn-outline-primary btn-sm' disabled>- Remove</button>
+			<button type='button' class='btn btn-outline-primary btn-sm remove-btn' disabled>- Remove</button>
 			<button type='button' class='btn btn-outline-info btn-sm save-btn mx-3' disabled>Save</button>
 			<button type='button' class='btn btn-outline-info btn-sm export-btn'>Export</button>
 			<button type='button' class='btn btn-outline-info btn-sm import-btn' data-translation-type='form'>Import</button>
@@ -79,7 +79,7 @@ function printProjectCard($project_info) {
 		<div class='table-controls ml-3'>
 			<button type='button' class='btn btn-outline-primary btn-sm'>+ Row</button>
 			<button type='button' class='btn btn-outline-primary btn-sm'>+ Column</button>
-			<button type='button' class='btn btn-outline-primary btn-sm' disabled>- Remove</button>
+			<button type='button' class='btn btn-outline-primary btn-sm remove-btn' disabled>- Remove</button>
 			<button type='button' class='btn btn-outline-info btn-sm save-btn mx-3' disabled>Save</button>
 			<button type='button' class='btn btn-outline-info btn-sm export-btn'>Export</button>
 			<button type='button' class='btn btn-outline-info btn-sm import-btn' data-translation-type='event'>Import</button>

--- a/config_translations.php
+++ b/config_translations.php
@@ -1,0 +1,144 @@
+
+<!-- Bootstrap latest compiled and minified JavaScript -->
+<!-- <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script> -->
+
+<?php
+
+carl_log("config_translations.php GET: " . print_r($_GET, true));
+carl_log("config_translations.php POST: " . print_r($_POST, true));
+carl_log("config_translations.php FILES: " . print_r($_FILES, true));
+
+if (isset($_POST['project-api-key']) and isset($_POST['server-url'])) {
+	$module->importTranslationsFile();
+}
+
+$export_servers = $module->getSubSettings('export-servers');
+$import_servers = $module->getSubSettings('servers');
+
+function printProjectCard($project_info) {
+	?>
+	<div class='card'>
+		<div class='card-title m-3'>
+			<h3 class='pb-1'>Server #<?= $project_info['server-index'] ?> - Project #<?= $project_info['project-index'] ?></h3>
+			<span>API Key: </span><b><span class='project-api-key'><?= $project_info['api-key'] ?></span></b>
+			<br>
+			<span>Server URL: </span><b><span class='server-url'><?= $project_info['url'] ?></span></b>
+			<span class='server-type'><?= $project_info['server-type'] ?></span>
+		</div>
+		<div class='table-controls ml-3'>
+			<button type='button' class='btn btn-outline-primary btn-sm'>+ Row</button>
+			<button type='button' class='btn btn-outline-primary btn-sm'>+ Column</button>
+			<button type='button' class='btn btn-outline-primary btn-sm' disabled>- Remove</button>
+			<button type='button' class='btn btn-outline-info btn-sm save-btn mx-3' disabled>Save</button>
+			<button type='button' class='btn btn-outline-info btn-sm'>Export</button>
+			<button type='button' class='btn btn-outline-info btn-sm import-btn'>Import</button>
+		</div>
+		<div class='card-body'>
+			<h4>Form Translations Table</h4>
+			<table class='table translations-tbl'>
+				<thead>
+					<tr>
+						<th>Local Form Name</th>
+						<th>Translated Name #1</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td><div contenteditable>Instrument A</div></td>
+						<td><div contenteditable>My Instrument</div></td>
+					</tr>
+					<tr>
+						<td><div contenteditable>Instrument A</div></td>
+						<td><div contenteditable>My Instrument</div></td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		
+		<div class='table-controls ml-3'>
+			<button type='button' class='btn btn-outline-primary btn-sm'>+ Row</button>
+			<button type='button' class='btn btn-outline-primary btn-sm'>+ Column</button>
+			<button type='button' class='btn btn-outline-primary btn-sm' disabled>- Remove</button>
+			<button type='button' class='btn btn-outline-info btn-sm save-btn mx-3' disabled>Save</button>
+			<button type='button' class='btn btn-outline-info btn-sm'>Export</button>
+			<button type='button' class='btn btn-outline-info btn-sm import-btn'>Import</button>
+		</div>
+		<div class='card-body'>
+			<h4>Event Translations Table</h4>
+			<table class='table translations-tbl'>
+				<thead>
+					<tr>
+						<th>Local Form Name</th>
+						<th>Translated Name #1</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td><div contenteditable>Instrument A</div></td>
+						<td><div contenteditable>My Instrument</div></td>
+					</tr>
+					<tr>
+						<td><div contenteditable>Instrument A</div></td>
+						<td><div contenteditable>My Instrument</div></td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</div>
+	<br>
+	<?php
+}
+
+foreach ($import_servers as $server_i => $server) {
+	$url = $server['redcap-url'];
+	foreach ($server['projects'] as $project_i => $project) {
+		$project['url'] = $url;
+		$project['server-index'] = $server_i + 1;
+		$project['server-type'] = 'import';
+		$project['project-index'] = $project_i + 1;
+		printProjectCard($project);
+	}
+}
+
+echo "<pre>export_servers:\n" . print_r($export_servers, true) . "</pre>";
+echo "<pre>import_servers:\n" . print_r($import_servers, true) . "</pre>";
+
+?>
+<!-- file import modal -->
+<div id="import-translations" class="modal" tabindex="-1" role="dialog">
+	<div class="modal-dialog" role="document">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h5 class="modal-title">Import Translations CSV File</h5>
+				<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+					<span aria-hidden="true">&times;</span>
+				</button>
+			</div>
+			<div class="modal-body">
+				<p>Upload a CSV containing name translations below.<br>The first column should contain names local to this project.<br>Proceeding column values should contain the translated names.</p><br>
+				<form id='translation-file' action='?prefix=api_sync&page=config_translations&pid=<?= $module->getProjectId() ?>' enctype='multipart/form-data' method='POST'>
+					<div class="input-group">
+						<div class="custom-file">
+							<input type='hidden' name='project-api-key' id='project-api-key'>
+							<input type='hidden' name='server-url' id='server-url'>
+							<input type='hidden' name='server-type' id='server-type'>
+							<input type="file" class="custom-file-input" id="attach-file-1" name="attach-file-1" aria-describedby="attach-file-addon-1">
+							<label class="custom-file-label" for="attach-file-1">Choose file</label>
+						</div>
+						<div class="input-group-append">
+							<button class="btn btn-outline-secondary remove-file" type="button" id="attach-file-addon-1" style="line-height: 1.15; font-size: .8rem;">Remove</button>
+						</div>
+					</div>
+				</form>
+			</div>
+			<div class="modal-footer">
+				<button type="button" class="btn btn-primary" data-dismiss="modal" id="import-submit">Save</button>
+				<button type="button" class="btn btn-secondary" data-dismiss="modal" id="import-cancel">Cancel</button>
+			</div>
+		</div>
+	</div>
+</div>
+<script type='text/javascript'>
+	api_sync_module = {css_url: '<?= $module->getUrl("css/config_translations.css") ?>'}
+</script>
+<script type='text/javascript' src='<?= $module->getUrl('js/config_translations.js') ?>'></script>

--- a/config_translations.php
+++ b/config_translations.php
@@ -1,11 +1,24 @@
 <?php
 
-carl_log("config_translations.php GET: " . print_r($_GET, true));
+// carl_log("config_translations.php GET: " . print_r($_GET, true));
 carl_log("config_translations.php POST: " . print_r($_POST, true));
-carl_log("config_translations.php FILES: " . print_r($_FILES, true));
+// carl_log("config_translations.php FILES: " . print_r($_FILES, true));
 
 if (isset($_POST['project-api-key']) and isset($_POST['server-url'])) {
-	$import_error_message = $module->importTranslationsFile();
+	if (isset($_POST['table_saved'])) {
+		$table_saved_error_message = $module->importTranslationsTable();
+		
+		header('Content-type: application/json');
+		$response = new \stdClass();
+		$response->success = true;
+		if (empty($table_saved_error_message)) {
+			$response->success = false;
+			$response->error = $table_saved_error_message;
+		}
+		exit(json_encode($response));
+	} else {
+		$import_error_message = $module->importTranslationsFile();
+	}
 }
 
 $export_servers = $module->getSubSettings('export-servers');
@@ -152,7 +165,9 @@ echo "<pre>import_servers:\n" . print_r($import_servers, true) . "</pre>";
 <script type='text/javascript'>
 	api_sync_module = {
 		css_url: '<?= $module->getUrl("css/config_translations.css") ?>',
-		import_error_message: "<?= $import_error_message ?>"
+		import_error_message: "<?= $import_error_message ?>",
+		table_saved_error_message: "<?= $table_saved_error_message ?>",
+		pid: "<?= $module->getProjectId() ?>"
 	}
 </script>
 <script type='text/javascript' src='<?= $module->getUrl('js/config_translations.js') ?>'></script>

--- a/config_translations.php
+++ b/config_translations.php
@@ -14,6 +14,42 @@ if (isset($_POST['project-api-key']) and isset($_POST['server-url'])) {
 $export_servers = $module->getSubSettings('export-servers');
 $import_servers = $module->getSubSettings('servers');
 
+function printTranslationsTable($translations = [], $type) {
+	$row_count = count($translations);
+	if (!empty($row_count)) {
+		$column_count = count($translations[0]);
+	}
+	
+	?>
+	<h4><?= ucfirst($type) ?> Translations Table</h4>
+	<table class='table translations-tbl'>
+		<thead>
+			<tr>
+				<th>Local <?= ucfirst($type) ?> Name</th>
+				<?php
+				if (empty($column_count)) {
+					echo "<th>Translated Name #1</th>";
+				} else {
+					for ($i = 1; $i <= ($column_count - 1); $i++) {
+						echo "<th>Translated Name #$i</th>";
+					}
+				}
+				?>
+			</tr>
+		</thead>
+		<tbody>
+			<?php foreach($translations as $row) {
+				echo "<tr>";
+				foreach($row as $name) {
+					echo "<td><div contenteditable>$name</div></td>";
+				}
+				echo "</tr>";
+			}?>
+		</tbody>
+	</table>
+	<?php
+}
+
 function printProjectCard($project_info) {
 	?>
 	<div class='card'>
@@ -33,25 +69,14 @@ function printProjectCard($project_info) {
 			<button type='button' class='btn btn-outline-info btn-sm import-btn' data-translation-type='form'>Import</button>
 		</div>
 		<div class='card-body'>
-			<h4>Form Translations Table</h4>
-			<table class='table translations-tbl'>
-				<thead>
-					<tr>
-						<th>Local Form Name</th>
-						<th>Translated Name #1</th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<td><div contenteditable>Instrument A</div></td>
-						<td><div contenteditable>My Instrument</div></td>
-					</tr>
-					<tr>
-						<td><div contenteditable>Instrument A</div></td>
-						<td><div contenteditable>My Instrument</div></td>
-					</tr>
-				</tbody>
-			</table>
+			<?php
+			if ($project_info['server-type'] == 'export') {
+				$translations = json_decode($project_info['export-form-translations']);
+			} else {
+				$translations = json_decode($project_info['form-translations']);
+			}
+			printTranslationsTable($translations, 'form');
+			?>
 		</div>
 		
 		<div class='table-controls ml-3'>
@@ -63,17 +88,14 @@ function printProjectCard($project_info) {
 			<button type='button' class='btn btn-outline-info btn-sm import-btn' data-translation-type='event'>Import</button>
 		</div>
 		<div class='card-body'>
-			<h4>Event Translations Table</h4>
-			<table class='table translations-tbl'>
-				<thead>
-					<tr>
-						<th>Local Form Name</th>
-						<th>Translated Name #1</th>
-					</tr>
-				</thead>
-				<tbody>
-				</tbody>
-			</table>
+			<?php
+			if ($project_info['server-type'] == 'export') {
+				$translations = json_decode($project_info['export-event-translations']);
+			} else {
+				$translations = json_decode($project_info['event-translations']);
+			}
+			printTranslationsTable($translations, 'event');
+			?>
 		</div>
 	</div>
 	<br>

--- a/config_translations.php
+++ b/config_translations.php
@@ -58,8 +58,8 @@ function printProjectCard($project_info) {
 			<span class='server-type'><?= $project_info['server-type'] ?></span>
 		</div>
 		<div class='table-controls ml-3'>
-			<button type='button' class='btn btn-outline-primary btn-sm'>+ Row</button>
-			<button type='button' class='btn btn-outline-primary btn-sm'>+ Column</button>
+			<button type='button' class='btn btn-outline-primary btn-sm add-row-btn'>+ Row</button>
+			<button type='button' class='btn btn-outline-primary btn-sm add-col-btn'>+ Column</button>
 			<button type='button' class='btn btn-outline-primary btn-sm remove-btn' disabled>- Remove</button>
 			<button type='button' class='btn btn-outline-info btn-sm save-btn mx-3' disabled>Save</button>
 			<button type='button' class='btn btn-outline-info btn-sm export-btn'>Export</button>
@@ -77,8 +77,8 @@ function printProjectCard($project_info) {
 		</div>
 		
 		<div class='table-controls ml-3'>
-			<button type='button' class='btn btn-outline-primary btn-sm'>+ Row</button>
-			<button type='button' class='btn btn-outline-primary btn-sm'>+ Column</button>
+			<button type='button' class='btn btn-outline-primary btn-sm add-row-btn'>+ Row</button>
+			<button type='button' class='btn btn-outline-primary btn-sm add-col-btn'>+ Column</button>
 			<button type='button' class='btn btn-outline-primary btn-sm remove-btn' disabled>- Remove</button>
 			<button type='button' class='btn btn-outline-info btn-sm save-btn mx-3' disabled>Save</button>
 			<button type='button' class='btn btn-outline-info btn-sm export-btn'>Export</button>

--- a/config_translations.php
+++ b/config_translations.php
@@ -1,5 +1,4 @@
 <?php
-
 if (isset($_POST['project-api-key']) and isset($_POST['server-url'])) {
 	if (isset($_POST['table_saved'])) {
 		$table_saved_error_message = $module->importTranslationsTable();
@@ -10,7 +9,6 @@ if (isset($_POST['project-api-key']) and isset($_POST['server-url'])) {
 			$response->success = false;
 			$response->error = $table_saved_error_message;
 		}
-		carl_log($response);
 		
 		header('Content-type: application/json');
 		exit(json_encode($response));
@@ -18,6 +16,7 @@ if (isset($_POST['project-api-key']) and isset($_POST['server-url'])) {
 		$import_error_message = $module->importTranslationsFile();
 	}
 }
+require_once APP_PATH_DOCROOT . 'ProjectGeneral/header.php';
 
 $export_servers = $module->getSubSettings('export-servers');
 $import_servers = $module->getSubSettings('servers');
@@ -152,3 +151,6 @@ foreach ([$export_servers, $import_servers] as $server_set) {
 	}
 </script>
 <script type='text/javascript' src='<?= $module->getUrl('js/config_translations.js') ?>'></script>
+
+<?php
+require_once APP_PATH_DOCROOT . 'ProjectGeneral/footer.php';

--- a/config_translations.php
+++ b/config_translations.php
@@ -7,9 +7,8 @@
 carl_log("config_translations.php GET: " . print_r($_GET, true));
 carl_log("config_translations.php POST: " . print_r($_POST, true));
 carl_log("config_translations.php FILES: " . print_r($_FILES, true));
-
 if (isset($_POST['project-api-key']) and isset($_POST['server-url'])) {
-	$module->importTranslationsFile();
+	$import_error_message = $module->importTranslationsFile();
 }
 
 $export_servers = $module->getSubSettings('export-servers');
@@ -31,7 +30,7 @@ function printProjectCard($project_info) {
 			<button type='button' class='btn btn-outline-primary btn-sm' disabled>- Remove</button>
 			<button type='button' class='btn btn-outline-info btn-sm save-btn mx-3' disabled>Save</button>
 			<button type='button' class='btn btn-outline-info btn-sm'>Export</button>
-			<button type='button' class='btn btn-outline-info btn-sm import-btn'>Import</button>
+			<button type='button' class='btn btn-outline-info btn-sm import-btn' data-translation-type='form'>Import</button>
 		</div>
 		<div class='card-body'>
 			<h4>Form Translations Table</h4>
@@ -61,7 +60,7 @@ function printProjectCard($project_info) {
 			<button type='button' class='btn btn-outline-primary btn-sm' disabled>- Remove</button>
 			<button type='button' class='btn btn-outline-info btn-sm save-btn mx-3' disabled>Save</button>
 			<button type='button' class='btn btn-outline-info btn-sm'>Export</button>
-			<button type='button' class='btn btn-outline-info btn-sm import-btn'>Import</button>
+			<button type='button' class='btn btn-outline-info btn-sm import-btn' data-translation-type='event'>Import</button>
 		</div>
 		<div class='card-body'>
 			<h4>Event Translations Table</h4>
@@ -73,14 +72,6 @@ function printProjectCard($project_info) {
 					</tr>
 				</thead>
 				<tbody>
-					<tr>
-						<td><div contenteditable>Instrument A</div></td>
-						<td><div contenteditable>My Instrument</div></td>
-					</tr>
-					<tr>
-						<td><div contenteditable>Instrument A</div></td>
-						<td><div contenteditable>My Instrument</div></td>
-					</tr>
 				</tbody>
 			</table>
 		</div>
@@ -122,6 +113,7 @@ echo "<pre>import_servers:\n" . print_r($import_servers, true) . "</pre>";
 							<input type='hidden' name='project-api-key' id='project-api-key'>
 							<input type='hidden' name='server-url' id='server-url'>
 							<input type='hidden' name='server-type' id='server-type'>
+							<input type='hidden' name='translations-type' id='translations-type'>
 							<input type="file" class="custom-file-input" id="attach-file-1" name="attach-file-1" aria-describedby="attach-file-addon-1">
 							<label class="custom-file-label" for="attach-file-1">Choose file</label>
 						</div>
@@ -139,6 +131,9 @@ echo "<pre>import_servers:\n" . print_r($import_servers, true) . "</pre>";
 	</div>
 </div>
 <script type='text/javascript'>
-	api_sync_module = {css_url: '<?= $module->getUrl("css/config_translations.css") ?>'}
+	api_sync_module = {
+		css_url: '<?= $module->getUrl("css/config_translations.css") ?>',
+		import_error_message: "<?= $import_error_message ?>"
+	}
 </script>
 <script type='text/javascript' src='<?= $module->getUrl('js/config_translations.js') ?>'></script>

--- a/config_translations.php
+++ b/config_translations.php
@@ -1,12 +1,9 @@
-
-<!-- Bootstrap latest compiled and minified JavaScript -->
-<!-- <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script> -->
-
 <?php
 
 carl_log("config_translations.php GET: " . print_r($_GET, true));
 carl_log("config_translations.php POST: " . print_r($_POST, true));
 carl_log("config_translations.php FILES: " . print_r($_FILES, true));
+
 if (isset($_POST['project-api-key']) and isset($_POST['server-url'])) {
 	$import_error_message = $module->importTranslationsFile();
 }
@@ -65,7 +62,7 @@ function printProjectCard($project_info) {
 			<button type='button' class='btn btn-outline-primary btn-sm'>+ Column</button>
 			<button type='button' class='btn btn-outline-primary btn-sm' disabled>- Remove</button>
 			<button type='button' class='btn btn-outline-info btn-sm save-btn mx-3' disabled>Save</button>
-			<button type='button' class='btn btn-outline-info btn-sm'>Export</button>
+			<button type='button' class='btn btn-outline-info btn-sm export-btn'>Export</button>
 			<button type='button' class='btn btn-outline-info btn-sm import-btn' data-translation-type='form'>Import</button>
 		</div>
 		<div class='card-body'>
@@ -84,7 +81,7 @@ function printProjectCard($project_info) {
 			<button type='button' class='btn btn-outline-primary btn-sm'>+ Column</button>
 			<button type='button' class='btn btn-outline-primary btn-sm' disabled>- Remove</button>
 			<button type='button' class='btn btn-outline-info btn-sm save-btn mx-3' disabled>Save</button>
-			<button type='button' class='btn btn-outline-info btn-sm'>Export</button>
+			<button type='button' class='btn btn-outline-info btn-sm export-btn'>Export</button>
 			<button type='button' class='btn btn-outline-info btn-sm import-btn' data-translation-type='event'>Import</button>
 		</div>
 		<div class='card-body'>

--- a/css/config_translations.css
+++ b/css/config_translations.css
@@ -1,0 +1,7 @@
+.highlight {
+	background-color: #afdcff;
+}
+
+span.server-type {
+	display: none;
+}

--- a/css/config_translations.css
+++ b/css/config_translations.css
@@ -1,3 +1,16 @@
+.alert.alert-primary {
+	border: 1px solid #b8daff !important;
+}
+.alert.alert-info {
+	border: 1px solid #bee5eb !important;
+}
+
+.card {
+	margin-bottom: 35px;
+	border: 1px solid rgba(0,0,0,0.225);
+	max-width: 95%;
+}
+
 .highlight {
 	background-color: #afdcff;
 }

--- a/css/config_translations.css
+++ b/css/config_translations.css
@@ -5,3 +5,29 @@
 span.server-type {
 	display: none;
 }
+
+.loader-container {
+	display: none;
+	flex-direction: row;
+	justify-content: center;
+	align-items: center;
+	align-content: center;
+	background-color: #00000011;
+	position: absolute;
+	width: 100%;
+	height: 100%;
+	top: 0px;
+	left: 0px;
+}
+.loader {
+	border: 16px solid #f3f3f3; /* Light grey */
+	border-top: 16px solid #3498db; /* Blue */
+	border-radius: 50%;
+	width: 120px;
+	height: 120px;
+	animation: spin 2s linear infinite;
+}
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/js/config_translations.js
+++ b/js/config_translations.js
@@ -18,23 +18,55 @@ $(document).ready(function() {
 
 	// // EVENT HANDLING
 	// highlight clicked rows/cols
+	$('body').on('click', null, function(event) {
+		// remove existing highlights
+		$('tr, td, th').removeClass('highlight');
+		$('.remove-btn').attr('disabled', true);
+	});
 	$('body').on('click', '.translations-tbl td', function(event) {
 		// remove existing highlights
 		$('tr, td, th').removeClass('highlight');
+		$('.remove-btn').attr('disabled', true);
 		
 		var clicked_row = $(this).closest('tr');
 		$(clicked_row).addClass('highlight');
-		console.log('clicked_row', clicked_row);
+		
+		$(this).closest('.card-body').prev('div.table-controls').find('.remove-btn').attr('disabled', false);
+		event.stopPropagation();
 	});
 	$('body').on('click', '.translations-tbl th', function(event) {
 		// remove existing highlights
 		$('tr, td, th').removeClass('highlight');
+		$('.remove-btn').attr('disabled', true);
 		
 		$(this).addClass('highlight');
 		var col_index = $(this).index();
 		$(this).closest('.translations-tbl').find('td:nth-child(' + (col_index + 1) + ')').each(function(i, td) {
 			$(td).addClass('highlight');
 		});
+		$(this).closest('.card-body').prev('div.table-controls').find('.remove-btn').attr('disabled', false);
+		event.stopPropagation();
+	});
+
+	// remove highlighted table row or column
+	$('body').on('click', '.remove-btn', function(event) {
+		var tbl = $(this).parent().next('.card-body').find('.translations-tbl')
+		var rows = $(tbl).find('tbody tr').length;
+		var cols = $(tbl).find('thead th').length;
+		var remove_mode = $('th.highlight').length > 0 ? 'col' : 'row';
+		
+		if ((rows > 0 && remove_mode == 'row') || (cols > 2 && remove_mode == 'col')) {
+			$('.highlight').remove();
+		}
+		
+		// rename column headings
+		if (remove_mode == 'col') {
+			$(tbl).find('th').each(function(i, th) {
+				if (i != 0) {
+					$(th).text('Translated Name #' + i);
+				}
+			});
+		}
 	});
 
 	// show import translations file modal
@@ -45,7 +77,6 @@ $(document).ready(function() {
 		var server_url = $(card).find('span.server-url').text();
 		var server_type = $(card).find('span.server-type').text();
 		var translations_type = $(this).attr('data-translation-type');
-		console.log('translations_type', translations_type);
 		
 		$("input#project-api-key").val(proj_api_key);
 		$("input#server-url").val(server_url);

--- a/js/config_translations.js
+++ b/js/config_translations.js
@@ -1,0 +1,62 @@
+api_sync_module.addTableRow = function() {
+	
+}
+
+// append stylesheet to head element of DOM
+$('head').append("<link rel='stylesheet' type='text/css' href='" + api_sync_module.css_url + "'/>");
+
+// // EVENT HANDLING
+// highlight clicked rows
+$('.translations-tbl').on('click', '.translations-tbl td', function(event) {
+	var clicked_row = $(this).find('tr');
+	$('tr').removeClass('highlight');
+	$(clicked_row).addClass('highlight');
+	console.log('clicked_row', clicked_row);
+});
+
+// show import translations file modal
+$('body').on('click', '.import-btn', function(event) {
+	// put project api key and server url in form
+	var card = $(this).closest('div.card');
+	var proj_api_key = $(card).find('span.project-api-key').text();
+	var server_url = $(card).find('span.server-url').text();
+	var server_type = $(card).find('span.server-type').text();
+	$("input#project-api-key").val(proj_api_key);
+	$("input#server-url").val(server_url);
+	$("input#server-type").val(server_type);
+	
+	$("#import-translations").modal("show");
+});
+
+// change display name in file upload input element
+$('body').on('change', ".custom-file-input", function() {		// attach file (and maybe add input)
+	var fileName = $(this).val().split('\\').pop()
+	if (fileName.length > 40) {
+		fileName = fileName.slice(0, 40) + "..."
+	}
+	
+	$(this).next('label').html(fileName)
+})
+
+// removed uploaded file
+$('body').on('click', ".remove-file", function() {				// click remove (remove file attachment/input)
+	var modal = $(this).closest('.modal-body')
+	var target_input = $(this).parent().prev('div').children('.custom-file-input')
+	var parent_group = $(this).closest('.input-group')
+	
+	if (modal.children('.input-group').length == 1) {
+		target_input.val('')
+		target_input.next('label').html("Choose file")
+	} else {
+		parent_group.remove()
+	}
+})
+
+// submit translations file
+$('body').on('click', "#import-submit", function() {
+	$("form#translation-file").submit();
+});
+
+if (window.history.replaceState) {
+	window.history.replaceState(null, null, window.location.href);
+}

--- a/js/config_translations.js
+++ b/js/config_translations.js
@@ -110,6 +110,7 @@ $(document).ready(function() {
 	});
 	
 	$('body').on('click', '.save-btn', function() {
+		var save_btn = this;
 		var tbl = $(this).parent().next('.card-body').find('.translations-tbl')
 		var tbl_csv = api_sync_module.serialize_table(tbl);
 		var card = $(this).closest('div.card');
@@ -134,7 +135,7 @@ $(document).ready(function() {
 			},
 			complete: function(response, status) {
 				$(loader).css('display', 'none');
-				$('.save-btn.btn-info').removeClass('btn-info').addClass('btn-outline-info');
+				$(save_btn).removeClass('btn-info').addClass('btn-outline-info');
 			}
 		});
 	});

--- a/js/config_translations.js
+++ b/js/config_translations.js
@@ -14,7 +14,7 @@ $(document).ready(function() {
 		$(tbody).children('tr').each(function(i, tr) {
 			var entries = [];
 			$(tr).find('td > div').each(function(j, div) {
-				entries.push($(div).text().trim());
+				entries.push($(div).text().trim().replaceAll(',', '_'));
 			});
 			lines.push(entries.join(', '));
 		});
@@ -72,6 +72,10 @@ $(document).ready(function() {
 
 	// add row or col
 	$('body').on('click', '.add-row-btn', function() {
+		var savebtn = $(this).closest('.card-body').prev('div.table-controls').find('.save-btn');
+		$(savebtn).removeClass('btn-outline-info btn-info');
+		$(savebtn).addClass('btn-info');
+		
 		var tbl = $(this).parent().next('.card-body').find('.translations-tbl')
 		var cols = $(tbl).find('thead th').length;
 		var new_row = "<tr class='border-bottom'>";
@@ -82,6 +86,10 @@ $(document).ready(function() {
 		$(tbl).find('tbody').append(new_row);
 	});
 	$('body').on('click', '.add-col-btn', function() {
+		var savebtn = $(this).closest('.card-body').prev('div.table-controls').find('.save-btn');
+		$(savebtn).removeClass('btn-outline-info btn-info');
+		$(savebtn).addClass('btn-info');
+		
 		var tbl = $(this).parent().next('.card-body').find('.translations-tbl')
 		$(tbl).find('thead tr').append('<th></th>');
 		$(tbl).find('tbody tr').each(function(i, row) {
@@ -92,6 +100,10 @@ $(document).ready(function() {
 
 	// remove highlighted table row or column
 	$('body').on('click', '.remove-btn', function() {
+		var savebtn = $(this).closest('.card-body').prev('div.table-controls').find('.save-btn');
+		$(savebtn).removeClass('btn-outline-info btn-info');
+		$(savebtn).addClass('btn-info');
+		
 		var tbl = $(this).parent().next('.card-body').find('.translations-tbl')
 		var rows = $(tbl).find('tbody tr').length;
 		var cols = $(tbl).find('thead th').length;
@@ -145,11 +157,6 @@ $(document).ready(function() {
 		var savebtn = $(this).closest('.card-body').prev('div.table-controls').find('.save-btn');
 		$(savebtn).removeClass('btn-outline-info btn-info');
 		$(savebtn).addClass('btn-info');
-		
-		// replace commas with underscores
-		var inputted_name = $(this).find('div').text();
-		var commas_replaced = inputted_name.replaceAll(',', '_');
-		$(this).find('div').html(commas_replaced);
 	});
 	
 	// export translations from table

--- a/js/config_translations.js
+++ b/js/config_translations.js
@@ -1,62 +1,72 @@
-api_sync_module.addTableRow = function() {
-	
-}
+$(document).ready(function() {
+	api_sync_module.addTableRow = function() {
+		
+	}
 
-// append stylesheet to head element of DOM
-$('head').append("<link rel='stylesheet' type='text/css' href='" + api_sync_module.css_url + "'/>");
+	// append stylesheet to head element of DOM
+	$('head').append("<link rel='stylesheet' type='text/css' href='" + api_sync_module.css_url + "'/>");
 
-// // EVENT HANDLING
-// highlight clicked rows
-$('.translations-tbl').on('click', '.translations-tbl td', function(event) {
-	var clicked_row = $(this).find('tr');
-	$('tr').removeClass('highlight');
-	$(clicked_row).addClass('highlight');
-	console.log('clicked_row', clicked_row);
-});
+	// // EVENT HANDLING
+	// highlight clicked rows
+	$('.translations-tbl').on('click', '.translations-tbl td', function(event) {
+		var clicked_row = $(this).find('tr');
+		$('tr').removeClass('highlight');
+		$(clicked_row).addClass('highlight');
+		console.log('clicked_row', clicked_row);
+	});
 
-// show import translations file modal
-$('body').on('click', '.import-btn', function(event) {
-	// put project api key and server url in form
-	var card = $(this).closest('div.card');
-	var proj_api_key = $(card).find('span.project-api-key').text();
-	var server_url = $(card).find('span.server-url').text();
-	var server_type = $(card).find('span.server-type').text();
-	$("input#project-api-key").val(proj_api_key);
-	$("input#server-url").val(server_url);
-	$("input#server-type").val(server_type);
-	
-	$("#import-translations").modal("show");
-});
+	// show import translations file modal
+	$('body').on('click', '.import-btn', function(event) {
+		// put project api key and server url in form
+		var card = $(this).closest('div.card');
+		var proj_api_key = $(card).find('span.project-api-key').text();
+		var server_url = $(card).find('span.server-url').text();
+		var server_type = $(card).find('span.server-type').text();
+		var translations_type = $(this).attr('data-translation-type');
+		console.log('translations_type', translations_type);
+		
+		$("input#project-api-key").val(proj_api_key);
+		$("input#server-url").val(server_url);
+		$("input#server-type").val(server_type);
+		$("input#translations-type").val(translations_type);
+		
+		$("#import-translations").modal("show");
+	});
 
-// change display name in file upload input element
-$('body').on('change', ".custom-file-input", function() {		// attach file (and maybe add input)
-	var fileName = $(this).val().split('\\').pop()
-	if (fileName.length > 40) {
-		fileName = fileName.slice(0, 40) + "..."
+	// change display name in file upload input element
+	$('body').on('change', ".custom-file-input", function() {		// attach file (and maybe add input)
+		var fileName = $(this).val().split('\\').pop()
+		if (fileName.length > 40) {
+			fileName = fileName.slice(0, 40) + "..."
+		}
+		
+		$(this).next('label').html(fileName)
+	})
+
+	// removed uploaded file
+	$('body').on('click', ".remove-file", function() {				// click remove (remove file attachment/input)
+		var modal = $(this).closest('.modal-body')
+		var target_input = $(this).parent().prev('div').children('.custom-file-input')
+		var parent_group = $(this).closest('.input-group')
+		
+		if (modal.children('.input-group').length == 1) {
+			target_input.val('')
+			target_input.next('label').html("Choose file")
+		} else {
+			parent_group.remove()
+		}
+	})
+
+	// submit translations file
+	$('body').on('click', "#import-submit", function() {
+		$("form#translation-file").submit();
+	});
+
+	if (window.history.replaceState) {
+		window.history.replaceState(null, null, window.location.href);
 	}
 	
-	$(this).next('label').html(fileName)
-})
-
-// removed uploaded file
-$('body').on('click', ".remove-file", function() {				// click remove (remove file attachment/input)
-	var modal = $(this).closest('.modal-body')
-	var target_input = $(this).parent().prev('div').children('.custom-file-input')
-	var parent_group = $(this).closest('.input-group')
-	
-	if (modal.children('.input-group').length == 1) {
-		target_input.val('')
-		target_input.next('label').html("Choose file")
-	} else {
-		parent_group.remove()
+	if (api_sync_module.import_error_message != '') {
+		alert(api_sync_module.import_error_message);
 	}
-})
-
-// submit translations file
-$('body').on('click', "#import-submit", function() {
-	$("form#translation-file").submit();
 });
-
-if (window.history.replaceState) {
-	window.history.replaceState(null, null, window.location.href);
-}

--- a/js/config_translations.js
+++ b/js/config_translations.js
@@ -130,7 +130,6 @@ $(document).ready(function() {
 				'server-type': $(card).find('span.server-type').text()
 			},
 			error: function(response, status, err) {
-				console.log('response', response.responseText);
 				alert("There was an issue saving translations updates: " + err);
 			},
 			complete: function(response, status) {

--- a/js/config_translations.js
+++ b/js/config_translations.js
@@ -1,6 +1,10 @@
 $(document).ready(function() {
-	api_sync_module.addTableRow = function() {
-		
+	api_sync_module.rename_columns = function(table) {
+		$(table).find('th').each(function(i, th) {
+			if (i != 0) {
+				$(th).text('Translated Name #' + i);
+			}
+		});
 	}
 
 	// append stylesheet to head element of DOM
@@ -48,6 +52,26 @@ $(document).ready(function() {
 		event.stopPropagation();
 	});
 
+	// add row or col
+	$('body').on('click', '.add-row-btn', function(event) {
+		var tbl = $(this).parent().next('.card-body').find('.translations-tbl')
+		var cols = $(tbl).find('thead th').length;
+		var new_row = "<tr>";
+		for (i = 0; i < cols; i++) {
+			new_row += "<td><div contenteditable></div></td>";
+		}
+		new_row += "</tr>";
+		$(tbl).find('tbody').append(new_row);
+	});
+	$('body').on('click', '.add-col-btn', function(event) {
+		var tbl = $(this).parent().next('.card-body').find('.translations-tbl')
+		$(tbl).find('thead tr').append('<th></th>');
+		$(tbl).find('tbody tr').each(function(i, row) {
+			$(row).append("<td><div contenteditable></div></td>");
+		});
+		api_sync_module.rename_columns(tbl);
+	});
+
 	// remove highlighted table row or column
 	$('body').on('click', '.remove-btn', function(event) {
 		var tbl = $(this).parent().next('.card-body').find('.translations-tbl')
@@ -61,11 +85,7 @@ $(document).ready(function() {
 		
 		// rename column headings
 		if (remove_mode == 'col') {
-			$(tbl).find('th').each(function(i, th) {
-				if (i != 0) {
-					$(th).text('Translated Name #' + i);
-				}
-			});
+			api_sync_module.rename_columns(tbl);
 		}
 	});
 

--- a/js/config_translations.js
+++ b/js/config_translations.js
@@ -145,6 +145,11 @@ $(document).ready(function() {
 		var savebtn = $(this).closest('.card-body').prev('div.table-controls').find('.save-btn');
 		$(savebtn).removeClass('btn-outline-info btn-info');
 		$(savebtn).addClass('btn-info');
+		
+		// replace commas with underscores
+		var inputted_name = $(this).find('div').text();
+		var commas_replaced = inputted_name.replaceAll(',', '_');
+		$(this).find('div').html(commas_replaced);
 	});
 	
 	// export translations from table

--- a/js/config_translations.js
+++ b/js/config_translations.js
@@ -33,6 +33,31 @@ $(document).ready(function() {
 		$("#import-translations").modal("show");
 	});
 
+	// export translations from table
+	$('body').on('click', '.export-btn', function(event) {
+		// write csv_contents string using table contents
+		var tbody = $(this).parent().next().find('.translations-tbl > tbody');
+		var lines = [];
+		$(tbody).children('tr').each(function(i, tr) {
+			var entries = [];
+			$(tr).find('td > div').each(function(j, div) {
+				entries.push($(div).text().trim());
+			});
+			lines.push(entries.join(', '));
+		});
+		var csv_contents = lines.join('\r\n');
+		
+		// create temporary anchor element to download file to user
+		var a = $("<a style='display: none;'/>");
+		var url = window.URL.createObjectURL(new Blob([csv_contents], {type: "data:text/csv;charset=utf-8"}));
+		a.attr("href", url);
+		a.attr("download", 'translations.csv');
+		$("body").append(a);
+		a[0].click();
+		window.URL.revokeObjectURL(url);
+		a.remove();
+	});
+
 	// change display name in file upload input element
 	$('body').on('change', ".custom-file-input", function() {		// attach file (and maybe add input)
 		var fileName = $(this).val().split('\\').pop()

--- a/js/config_translations.js
+++ b/js/config_translations.js
@@ -42,30 +42,31 @@ $(document).ready(function() {
 	$('body').on('click', null, function() {
 		// remove existing highlights
 		$('tr, td, th').removeClass('highlight');
-		$('.remove-btn').attr('disabled', true);
+		$('.remove-btn.btn-primary').removeClass('btn-primary').addClass('btn-outline-primary');
 	});
 	$('body').on('click', '.translations-tbl td', function(event) {
 		// remove existing highlights
 		$('tr, td, th').removeClass('highlight');
-		$('.remove-btn').attr('disabled', true);
 		
 		var clicked_row = $(this).closest('tr');
 		$(clicked_row).addClass('highlight');
 		
-		$(this).closest('.card-body').prev('div.table-controls').find('.remove-btn').attr('disabled', false);
+		$('.remove-btn.btn-primary').removeClass('btn-primary').addClass('btn-outline-primary');
+		$(this).closest('.card-body').prev('div.table-controls').find('.remove-btn').removeClass('btn-outline-primary').addClass('btn-primary');
 		event.stopPropagation();
 	});
 	$('body').on('click', '.translations-tbl th', function(event) {
 		// remove existing highlights
 		$('tr, td, th').removeClass('highlight');
-		$('.remove-btn').attr('disabled', true);
 		
 		$(this).addClass('highlight');
 		var col_index = $(this).index();
 		$(this).closest('.translations-tbl').find('td:nth-child(' + (col_index + 1) + ')').each(function(i, td) {
 			$(td).addClass('highlight');
 		});
-		$(this).closest('.card-body').prev('div.table-controls').find('.remove-btn').attr('disabled', false);
+		
+		$('.remove-btn.btn-primary').removeClass('btn-primary').addClass('btn-outline-primary');
+		$(this).closest('.card-body').prev('div.table-controls').find('.remove-btn').removeClass('btn-outline-primary').addClass('btn-primary');
 		event.stopPropagation();
 	});
 
@@ -73,7 +74,7 @@ $(document).ready(function() {
 	$('body').on('click', '.add-row-btn', function() {
 		var tbl = $(this).parent().next('.card-body').find('.translations-tbl')
 		var cols = $(tbl).find('thead th').length;
-		var new_row = "<tr>";
+		var new_row = "<tr class='border-bottom'>";
 		for (i = 0; i < cols; i++) {
 			new_row += "<td><div contenteditable></div></td>";
 		}
@@ -98,6 +99,8 @@ $(document).ready(function() {
 		
 		if ((rows > 0 && remove_mode == 'row') || (cols > 2 && remove_mode == 'col')) {
 			$('.highlight').remove();
+			$('.remove-btn').removeClass('btn-outline-primary btn-primary')
+			$('.remove-btn').addClass('btn-outline-primary')
 		}
 		
 		// rename column headings
@@ -110,24 +113,38 @@ $(document).ready(function() {
 		var tbl = $(this).parent().next('.card-body').find('.translations-tbl')
 		var tbl_csv = api_sync_module.serialize_table(tbl);
 		var card = $(this).closest('div.card');
-		$(this).attr('disabled', true);
+		
+		// show loader
+		var loader = $(card).find('.loader-container');
+		$(loader).css('display', 'flex');
+		
 		$.ajax({
 			type: 'POST',
 			url: '?prefix=api_sync&page=config_translations&pid=' + api_sync_module.pid,
 			data: {
 				table_saved: true,
 				translations: tbl_csv,
-				'translations-type': $(card).find('.import-btn').attr('data-translation-type'),
+				'translations-type': $(this).attr('data-translation-type'),
 				'project-api-key': $(card).find('span.project-api-key').text(),
 				'server-url': (card).find('span.server-url').text(),
 				'server-type': $(card).find('span.server-type').text()
+			},
+			error: function(response, status, err) {
+				console.log('response', response.responseText);
+				alert("There was an issue saving translations updates: " + err);
+			},
+			complete: function(response, status) {
+				$(loader).css('display', 'none');
+				$('.save-btn.btn-info').removeClass('btn-info').addClass('btn-outline-info');
 			}
 		});
 	});
 	
 	// enable save button when translations table changes
 	$('body').on('input', '.translations-tbl td', function() {
-		$(this).closest('.card-body').prev('div.table-controls').find('.save-btn').attr('disabled', false);
+		var savebtn = $(this).closest('.card-body').prev('div.table-controls').find('.save-btn');
+		$(savebtn).removeClass('btn-outline-info btn-info');
+		$(savebtn).addClass('btn-info');
 	});
 	
 	// export translations from table

--- a/js/config_translations.js
+++ b/js/config_translations.js
@@ -5,14 +5,36 @@ $(document).ready(function() {
 
 	// append stylesheet to head element of DOM
 	$('head').append("<link rel='stylesheet' type='text/css' href='" + api_sync_module.css_url + "'/>");
+	
+	// prevent form resubmission
+	if (window.history.replaceState) {
+		window.history.replaceState(null, null, window.location.href);
+	}
+	
+	// show import error
+	if (api_sync_module.import_error_message != '') {
+		alert(api_sync_module.import_error_message);
+	}
 
 	// // EVENT HANDLING
-	// highlight clicked rows
-	$('.translations-tbl').on('click', '.translations-tbl td', function(event) {
-		var clicked_row = $(this).find('tr');
-		$('tr').removeClass('highlight');
+	// highlight clicked rows/cols
+	$('body').on('click', '.translations-tbl td', function(event) {
+		// remove existing highlights
+		$('tr, td, th').removeClass('highlight');
+		
+		var clicked_row = $(this).closest('tr');
 		$(clicked_row).addClass('highlight');
 		console.log('clicked_row', clicked_row);
+	});
+	$('body').on('click', '.translations-tbl th', function(event) {
+		// remove existing highlights
+		$('tr, td, th').removeClass('highlight');
+		
+		$(this).addClass('highlight');
+		var col_index = $(this).index();
+		$(this).closest('.translations-tbl').find('td:nth-child(' + (col_index + 1) + ')').each(function(i, td) {
+			$(td).addClass('highlight');
+		});
 	});
 
 	// show import translations file modal
@@ -86,12 +108,4 @@ $(document).ready(function() {
 	$('body').on('click', "#import-submit", function() {
 		$("form#translation-file").submit();
 	});
-
-	if (window.history.replaceState) {
-		window.history.replaceState(null, null, window.location.href);
-	}
-	
-	if (api_sync_module.import_error_message != '') {
-		alert(api_sync_module.import_error_message);
-	}
 });

--- a/tests/TranslationTest.php
+++ b/tests/TranslationTest.php
@@ -7,7 +7,7 @@ class TranslationTest extends BaseTest{
 		
         $project1 = [];
 		$module->buildTranslations($project1);
-		$this->assertSame($project1, []);
+		$this->assertSame([], $project1);
 		
 		$project2 = [
 			'form-translations' => '[["Instrument A"," My First Instrument"," My First Instrument_2"],["Instrument B"," Instrument 2"," Instrument 2_2"]]',

--- a/tests/TranslationTest.php
+++ b/tests/TranslationTest.php
@@ -1,0 +1,86 @@
+<?php
+namespace Vanderbilt\APISyncExternalModule;
+
+class TranslationTest extends BaseTest{
+    function test_build_translations() {
+		$module = new APISyncExternalModule();
+		
+        $project1 = [];
+		$module->buildTranslations($project1);
+		$this->assertSame($project1, []);
+		
+		$project2 = [
+			'form-translations' => '[["Instrument A"," My First Instrument"," My First Instrument_2"],["Instrument B"," Instrument 2"," Instrument 2_2"]]',
+			'event-translations' => '[["E_1"," E1"," EA"],["E_2"," E2"," EB"],["E_3"," E3"," EC"]]'
+		];
+		$module->buildTranslations($project2);
+		$this->assertSame($project2, [
+			'form-translations' => [
+				['instrument_a', 'my_first_instrument', 'my_first_instrument_2'],
+				['instrument_b', 'instrument_2', 'instrument_2_2']
+			],
+			'event-translations' => [
+				['e_1', 'e1', 'ea'],
+				['e_2', 'e2', 'eb'],
+				['e_3', 'e3', 'ec']
+			]
+		]);
+    }
+	function test_import_translate_data() {
+		$module = new APISyncExternalModule();
+		
+		$project = [
+			'form-translations' => [
+				['instrument_a', 'my_first_instrument', 'my_first_instrument_2'],
+				['instrument_b', 'instrument_2', 'instrument_2_2']
+			],
+			'event-translations' => [
+				['e_1', 'e1', 'ea'],
+				['e_2', 'e2', 'eb'],
+				['e_3', 'e3', 'ec']
+			]
+		];
+        $data = [
+			[
+				'my_rid_field' => 'src1_1',
+				'redcap_event_name' => 'e1_arm_1',
+				'redcap_repeat_instrument' => null,
+				'test' => 'a',
+				'my_first_instrument_complete' => 0,
+				'instrument_2_complete' => 0
+			],
+			[
+				'my_rid_field' => 'src1_1',
+				'redcap_event_name' => 'e2_arm_1',
+				'redcap_repeat_instrument' => 'my_first_instrument',
+				'redcap_repeat_instance' => '1',
+				'test' => 'b',
+				'my_first_instrument_complete' => '0',
+				'instrument_2_complete' => ''
+			]
+		];
+		
+		$module->translateFormNames($data, $project);
+		$module->translateEventNames($data, $project);
+		
+		$this->assertSame([
+			[
+				'my_rid_field' => 'src1_1',
+				'redcap_event_name' => 'e_1_arm_1',
+				'redcap_repeat_instrument' => null,
+				'test' => 'a',
+				'instrument_a_complete' => 0,
+				'instrument_b_complete' => 0
+			],
+			[
+				'my_rid_field' => 'src1_1',
+				'redcap_event_name' => 'e_2_arm_1',
+				'redcap_repeat_instrument' => 'instrument_a',
+				'redcap_repeat_instance' => '1',
+				'test' => 'b',
+				'instrument_a_complete' => '0',
+				'instrument_b_complete' => ''
+			]
+		], $data);
+    }
+}


### PR DESCRIPTION
[data_translation_log.txt](https://github.com/vanderbilt-redcap/api-sync-module/files/5968439/data_translation_log.txt)

[prepare_translations_php.txt](https://github.com/vanderbilt-redcap/api-sync-module/files/5968441/prepare_translations_php.txt)

Hi Mark!

This PR shows what I've done so far for the API Sync form/event rename feature. I've tested this on a small longitudinal project with repeating events and repeating instruments (both). Cursory testing seems to indicate that, after changing the source project's instrument and event names and running the prepare_translations script, the import process works correctly for all records and instances.

I've attached a data_translation_log.txt file. This shows what translated export data looks like compared to the original.

I've also attached the prepare_translations_php.txt (github won't let me upload .php files here) that shows how I've temporarily logged some translation arrays to the module log table. It should be fairly trivial to add an interface to allow admins to upload their own translations -- that's what I'll be working on next.

Let me know what you think!

P.S. You'll notice I've shimmed 'countLogs' instead of upgrading the module's framework-version property in config.json. I was thinking I'd leave the shim in until everything else is finalized. I plan on upgrading the module to version 5 once I've ensured the requested functionality is safely implemented.
