### PR TITLE
Create initial working version of API sync activity digest page

### DIFF
--- a/APISyncExternalModule.php
+++ b/APISyncExternalModule.php
@@ -1657,21 +1657,3 @@ class APISyncExternalModule extends \ExternalModules\AbstractExternalModule{
 		echo '<link rel="stylesheet" href="' . $this->getUrl($path) . '">';
 	}
 }
-
-// Shims for functions that don't exist in all PHP versions
-// This is safe because it's defined in the module's namespace.
-function array_key_first($array){
-	reset($array);
-	return key($array);
-}
-
-if (version_compare(PHP_VERSION, '8.0.0', "<")) {
-	function str_starts_with($haystack, $needle): bool {
-		// discussion for why strncmp was chosen: https://stackoverflow.com/a/2792233/7418735
-		return (strncmp($haystack, $needle, strlen($needle)) === 0);
-	}
-
-	function str_contains($haystack, $needle): bool {
-		return (strpos($haystack, $needle) !== false);
-	}
-}

--- a/APISyncExternalModule.php
+++ b/APISyncExternalModule.php
@@ -3,6 +3,7 @@ namespace Vanderbilt\APISyncExternalModule;
 
 require_once __DIR__ . '/classes/Progress.php';
 require_once __DIR__ . '/classes/BatchBuilder.php';
+require_once __DIR__ . '/classes/DigestLog.php';
 
 use DateTime;
 use Exception;
@@ -1650,6 +1651,10 @@ class APISyncExternalModule extends \ExternalModules\AbstractExternalModule{
 
 		// Return the $newValue for security scanners that aren't smart enough to detect the exception above.
 		return $newValue;
+	}
+
+	function includeCss($path) {
+		echo '<link rel="stylesheet" href="' . $this->getUrl($path) . '">';
 	}
 }
 

--- a/APISyncExternalModule.php
+++ b/APISyncExternalModule.php
@@ -1426,7 +1426,7 @@ class APISyncExternalModule extends \ExternalModules\AbstractExternalModule{
 
 	private function getProjectTypePrefix(&$project) {
 		foreach ($project as $setting_name => $setting_value) {
-			if (strpos($setting_name, 'export-') !== false) {
+			if (str_contains($setting_name, 'export-')) {
 				return 'export-';
 			}
 		}
@@ -1460,7 +1460,7 @@ class APISyncExternalModule extends \ExternalModules\AbstractExternalModule{
 		$form_name = strip_tags(label_decode($form_label));
 		$form_name = preg_replace("/[^a-z0-9_]/", "", str_replace(" ", "_", strtolower(html_entity_decode($form_name, ENT_QUOTES))));
 		// Remove any double underscores, beginning numerals, and beginning/ending underscores
-		while (strpos($form_name, "__") !== false) 		$form_name = str_replace("__", "_", $form_name);
+		while (str_contains($form_name, "__")) 			$form_name = str_replace("__", "_", $form_name);
 		while (substr($form_name, 0, 1) == "_") 		$form_name = substr($form_name, 1);
 		while (substr($form_name, -1) == "_") 			$form_name = substr($form_name, 0, -1);
 		while (is_numeric(substr($form_name, 0, 1))) 	$form_name = substr($form_name, 1);
@@ -1658,9 +1658,20 @@ class APISyncExternalModule extends \ExternalModules\AbstractExternalModule{
 	}
 }
 
-// Shim for function that doesn't exist until php 7.
+// Shims for functions that don't exist in all PHP versions
 // This is safe because it's defined in the module's namespace.
 function array_key_first($array){
 	reset($array);
 	return key($array);
+}
+
+if (version_compare(PHP_VERSION, '8.0.0', "<")) {
+	function str_starts_with($haystack, $needle): bool {
+		// discussion for why strncmp was chosen: https://stackoverflow.com/a/2792233/7418735
+		return (strncmp($haystack, $needle, strlen($needle)) === 0);
+	}
+
+	function str_contains($haystack, $needle): bool {
+		return (strpos($haystack, $needle) !== false);
+	}
 }

--- a/classes/DigestLog.php
+++ b/classes/DigestLog.php
@@ -1,0 +1,171 @@
+<?php
+namespace Vanderbilt\APISyncExternalModule;
+
+class DigestLog
+{
+    private $accounted_urls = [];
+    private $unaccounted_urls = [];
+    private $url_statuses;
+    private $status_flags = [
+        'error' => false,
+        'cancelled' => false,
+        'complete' => false
+    ];
+    private $accumulated_record_imports = 0;
+    private $error_log_id = null;
+
+    private const MSG_SUBSTRS = [
+        "ERROR" => "An error occurred",
+        "CANCEL" => "Cancelling current import",
+        "IMPORT_START" => "Started import from",
+        "IMPORT_BATCH_FINISH" => "Import completed successfully for batch",
+        "IMPORT_FINISH" => "Finished import from",
+    ];
+
+    function __construct(APISyncExternalModule $module) {
+        $this->module = $module;
+        $settings = $module->getProjectSettings();
+        $unaccounted_urls = $settings['redcap-url'];
+
+        foreach ($unaccounted_urls as $url) {
+            $this->url_statuses[$url]['timestamp'] = '';
+            $this->url_statuses[$url]['import_source'] = $url;
+            $this->url_statuses[$url]['n_records'] = '0';
+            $this->url_statuses[$url]['status'] = 'Never run';
+            $this->url_statuses[$url]['error_log_id'] = null;
+        }
+
+        $this->unaccounted_urls = $unaccounted_urls;
+    }
+
+
+    private function resetStatus(): void {
+        $this->accumulated_record_imports = 0;
+        $this->error_log_id = null;
+
+        foreach ($this->status_flags as &$flag) { $flag = false; }
+    }
+
+
+    private function cumRecords(array $row): void {
+        $log_id = $row['log_id'];
+        $result = $this->module->queryLogs('select details where log_id = ?', [$log_id]);
+        $detail_row = $result->fetch_assoc();
+        try {
+            $details = json_decode($detail_row['details'], true);
+        } catch (Exception $e) {
+            return;
+        }
+
+        $batch_records = count($details['ids']);
+        $this->accumulated_record_imports += $batch_records;
+    }
+
+
+    private function assignAccumulatedRecords(string $url): void {
+        $this->url_statuses[$url]['n_records'] = $this->accumulated_record_imports;
+        $this->accumulated_record_imports = 0;
+    }
+
+
+    private function completeUrlEntry(string $url): void {
+        // prevent looking past one import event
+        $this->unaccounted_urls = array_diff($this->unaccounted_urls, [$url]);
+        $this->accounted_urls[] = $url;
+
+        $status_msg = "In progress";
+
+        if ($this->status_flags['complete']) {
+            $status_msg = "Complete";
+        }
+        if($this->status_flags['cancelled']) {
+            $status_msg = "This import was cancelled";
+        }
+        if ($this->status_flags['error']) {
+            $status_msg = "An error occurred";
+            // TODO: get details
+            $this->url_statuses[$url]['error_log_id'] = $this->error_log_id;
+        }
+
+        $this->assignAccumulatedRecords($url);
+        $this->resetStatus();
+
+        $this->url_statuses[$url]['status'] = $status_msg;
+    }
+
+    // analogue of str_starts_with for PHP 7 compatibility
+    private function strStartsWith($haystack, $needle): bool {
+        // discussion for why strncmp was chosen: https://stackoverflow.com/a/2792233/7418735
+        return (strncmp($haystack, $needle, strlen($needle)) === 0);
+    }
+
+
+    public function parseLogRow(array $row): void {
+        if ($this->strStartsWith($row['message'], self::MSG_SUBSTRS["ERROR"])) {
+            $this->status_flags['error'] = true;
+            $this->error_log_id = $row['log_id'];
+            return;
+        }
+        if ($this->strStartsWith($row['message'], self::MSG_SUBSTRS["CANCEL"])) {
+            $this->status_flags['cancelled'] = true;
+            return;
+        }
+
+        if ($this->strStartsWith($row['message'], self::MSG_SUBSTRS["IMPORT_BATCH_FINISH"])) {
+            // parse details for number of records imported in a batch
+            // NOTE: this assumes no concurrent import processes for different urls
+
+            $this->cumRecords($row);
+            return;
+        }
+
+        // ignore earlier pull events for already quantified urls
+        if ($this->strStartsWith($row['message'], self::MSG_SUBSTRS["IMPORT_START"])) {
+            foreach($this->accounted_urls as $url) {
+                if (strpos($row['message'], $url) !== false) {
+                    $this->resetStatus();
+                    return;
+                }
+            }
+        }
+
+        foreach($this->unaccounted_urls as $url) {
+            if (strpos($row['message'], $url) !== false) {
+                $this->url_statuses[$url]['timestamp'] = htmlentities($row['timestamp'], ENT_QUOTES);
+
+                if ($this->strStartsWith($row['message'], self::MSG_SUBSTRS["IMPORT_FINISH"])) {
+                    $this->status_flags['complete'] = true;
+                } elseif ($this->strStartsWith($row['message'], self::MSG_SUBSTRS["IMPORT_START"])) {
+                    $this->completeUrlEntry($url);
+                    $this->accounted_urls[] = $url;
+                }
+                return;
+            }
+        }
+    }
+
+
+    public function isDone(): bool {
+        return (!$this->unaccounted_urls);
+    }
+
+
+    public function getDigest(): array {
+        // NOTE: $url_statuses must have numeric indices as string indices are not handled by the frontend
+        return array_values($this->url_statuses);
+    }
+
+
+    public static function createLikeStatements(): string {
+        $sql = "(";
+
+        $is_first = true;
+        foreach (self::MSG_SUBSTRS as $k => $m) {
+            $sql .= ($is_first) ? " " : " OR ";
+            $sql .= "message LIKE '$m%'";
+            $is_first = false;
+        }
+        $sql .= ")";
+        return ($is_first) ? "true" : $sql;
+    }
+}

--- a/classes/DigestLog.php
+++ b/classes/DigestLog.php
@@ -93,25 +93,19 @@ class DigestLog
         $this->url_statuses[$url]['status'] = $status_msg;
     }
 
-    // analogue of str_starts_with for PHP 7 compatibility
-    private function strStartsWith($haystack, $needle): bool {
-        // discussion for why strncmp was chosen: https://stackoverflow.com/a/2792233/7418735
-        return (strncmp($haystack, $needle, strlen($needle)) === 0);
-    }
-
 
     public function parseLogRow(array $row): void {
-        if ($this->strStartsWith($row['message'], self::MSG_SUBSTRS["ERROR"])) {
+        if (str_starts_with($row['message'], self::MSG_SUBSTRS["ERROR"])) {
             $this->status_flags['error'] = true;
             $this->error_log_id = $row['log_id'];
             return;
         }
-        if ($this->strStartsWith($row['message'], self::MSG_SUBSTRS["CANCEL"])) {
+        if (str_starts_with($row['message'], self::MSG_SUBSTRS["CANCEL"])) {
             $this->status_flags['cancelled'] = true;
             return;
         }
 
-        if ($this->strStartsWith($row['message'], self::MSG_SUBSTRS["IMPORT_BATCH_FINISH"])) {
+        if (str_starts_with($row['message'], self::MSG_SUBSTRS["IMPORT_BATCH_FINISH"])) {
             // parse details for number of records imported in a batch
             // NOTE: this assumes no concurrent import processes for different urls
 
@@ -120,9 +114,9 @@ class DigestLog
         }
 
         // ignore earlier pull events for already quantified urls
-        if ($this->strStartsWith($row['message'], self::MSG_SUBSTRS["IMPORT_START"])) {
+        if (str_starts_with($row['message'], self::MSG_SUBSTRS["IMPORT_START"])) {
             foreach($this->accounted_urls as $url) {
-                if (strpos($row['message'], $url) !== false) {
+                if (str_contains($row['message'], $url)) {
                     $this->resetStatus();
                     return;
                 }
@@ -130,12 +124,12 @@ class DigestLog
         }
 
         foreach($this->unaccounted_urls as $url) {
-            if (strpos($row['message'], $url) !== false) {
+            if (str_contains($row['message'], $url)) {
                 $this->url_statuses[$url]['timestamp'] = htmlentities($row['timestamp'], ENT_QUOTES);
 
-                if ($this->strStartsWith($row['message'], self::MSG_SUBSTRS["IMPORT_FINISH"])) {
+                if (str_starts_with($row['message'], self::MSG_SUBSTRS["IMPORT_FINISH"])) {
                     $this->status_flags['complete'] = true;
-                } elseif ($this->strStartsWith($row['message'], self::MSG_SUBSTRS["IMPORT_START"])) {
+                } elseif (str_starts_with($row['message'], self::MSG_SUBSTRS["IMPORT_START"])) {
                     $this->completeUrlEntry($url);
                     $this->accounted_urls[] = $url;
                 }

--- a/classes/DigestLog.php
+++ b/classes/DigestLog.php
@@ -118,7 +118,7 @@ class DigestLog
             if (!$batch_progess) {
                 $batch_msg = substr($row['message'], strlen(self::MSG_SUBSTRS["IMPORT_BATCH_FINISH"]));
                 $batch_msg = strtok($batch_msg, ",");
-                $this->batch_progress = " (" . str_replace(" of ", "/", $batch_msg) . ")";
+                $this->batch_progress = " (" . str_replace(" of ", "/", $batch_msg) . " batches)";
             }
             return;
         }

--- a/classes/DigestLog.php
+++ b/classes/DigestLog.php
@@ -5,7 +5,7 @@ class DigestLog
 {
     private $accounted_urls = [];
     private $unaccounted_urls = [];
-    private $url_statuses;
+    private $url_statuses = [];
     private $status_flags = [
         'error' => false,
         'cancelled' => false,

--- a/classes/DigestLog.php
+++ b/classes/DigestLog.php
@@ -49,7 +49,7 @@ class DigestLog
     }
 
 
-    private function cumRecords(array $row): void {
+    private function accumulateRecords(array $row): void {
         $log_id = $row['log_id'];
         $result = $this->module->queryLogs('select details where log_id = ?', [$log_id]);
         $detail_row = $result->fetch_assoc();
@@ -113,7 +113,7 @@ class DigestLog
         if (str_starts_with($row['message'], self::MSG_SUBSTRS["IMPORT_BATCH_FINISH"])) {
             // parse details for number of records imported in a batch
             // NOTE: this assumes no concurrent import processes for different urls
-            $this->cumRecords($row);
+            $this->accumulateRecords($row);
 
             if (!$this->batch_progress) {
                 $batch_msg = substr($row['message'], strlen(self::MSG_SUBSTRS["IMPORT_BATCH_FINISH"]));

--- a/classes/DigestLog.php
+++ b/classes/DigestLog.php
@@ -115,7 +115,7 @@ class DigestLog
             // NOTE: this assumes no concurrent import processes for different urls
             $this->cumRecords($row);
 
-            if (!$batch_progess) {
+            if (!$this->batch_progress) {
                 $batch_msg = substr($row['message'], strlen(self::MSG_SUBSTRS["IMPORT_BATCH_FINISH"]));
                 $batch_msg = strtok($batch_msg, ",");
                 $this->batch_progress = " (" . str_replace(" of ", "/", $batch_msg) . " batches)";

--- a/config.json
+++ b/config.json
@@ -10,6 +10,9 @@
 			"institution": "Vanderbilt University Medical Center"
 		}
 	],
+	"compatibility": {
+		"redcap-version-min": "11.2.0"
+	},
 	"permissions": [],
 	"project-settings": [
 		{

--- a/config.json
+++ b/config.json
@@ -306,6 +306,12 @@
 				"icon": "databases_arrow",
 				"url": "config_translations.php",
 				"show-header-and-footer": false
+			},
+			{
+				"name": "API Sync - Latest Activity",
+				"icon": "list-alt",
+				"url": "log_digest.php",
+				"show-header-and-footer": true
 			}
 		]
 	},

--- a/css/pages.css
+++ b/css/pages.css
@@ -1,0 +1,66 @@
+<style>
+#api-sync-module-wrapper .top-button-container{
+    margin-top: 20px;
+    margin-bottom: 50px;
+}
+
+#api-sync-module-wrapper .top-button-container button{
+    margin: 3px;
+    min-width: 200px;
+}
+
+#api-sync-module-wrapper > label{
+    min-width: 70px;
+    margin-right: 5px;
+    text-align: right;
+}
+
+#api-sync-module-wrapper th{
+    font-weight: bold;
+}
+
+#api-sync-module-wrapper .remote-project-title{
+    margin-top: 5px;
+    margin-left: 15px;
+    font-weight: bold;
+}
+
+#api-sync-module-wrapper td.message{
+    max-width: 800px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+#api-sync-module-wrapper td:nth-child(3) button{
+    margin: 0px 2px;
+}
+
+#api-sync-module-wrapper a{
+    /* This currently only exists for the output of the formatURLForLogs() method. */
+    text-decoration: underline;
+}
+
+.api-sync-module-spinner{
+    position: relative;
+    height: 60px;
+    margin-top: -10px;
+}
+
+.swal2-popup{
+    font-size: 14px;
+    width: 500px;
+}
+
+.swal2-content{
+    font-weight: 500;
+}
+
+#api-sync-module-log-entries_wrapper{
+    max-width: 900px;
+    margin-right: 18px;
+}
+
+#api-sync-module-log-entries{
+    width: 100%;
+}
+</style>

--- a/get-log-digest.php
+++ b/get-log-digest.php
@@ -1,4 +1,5 @@
 <?php
+namespace Vanderbilt\APISyncExternalModule;
 $hasDetailsClause = "details != ''";
 const LOG_WINDOW_SIZE = 100;
 
@@ -8,7 +9,7 @@ if(version_compare(REDCAP_VERSION, '10.8.2', '<')){
 	$hasDetailsClause = 1;
 }
 
-$digestLog = new \Vanderbilt\APISyncExternalModule\DigestLog($module);
+$digestLog = new DigestLog($module);
 
 $module_id_query = $module->framework->query(
 	"SELECT external_module_id FROM redcap_external_modules WHERE directory_prefix = ?",

--- a/get-log-digest.php
+++ b/get-log-digest.php
@@ -1,5 +1,6 @@
 <?php
 $hasDetailsClause = "details != ''";
+const LOG_WINDOW_SIZE = 100;
 
 if(version_compare(REDCAP_VERSION, '10.8.2', '<')){
 	// This REDCap version does not support functions or comparisons in select log queries.
@@ -27,7 +28,7 @@ $results = $module->queryLogs("
 while($row = $results->fetch_assoc()){
 	$start_log_id = $row['max'];
 	$min_log_id = $row['min'];
-	$end_log_id = $start_log_id - 10;
+	$end_log_id = $start_log_id - LOG_WINDOW_SIZE;
 }
 
 $message_subtrings = $digestLog::createLikeStatements();
@@ -51,7 +52,7 @@ do  {
 	$all_accounted = $digestLog->isDone();
 
 	$start_log_id = $end_log_id;
-	$end_log_id = max($end_log_id - 10, $min_log_id);
+	$end_log_id = max($end_log_id - LOG_WINDOW_SIZE, $min_log_id);
 	if ($start_log_id == $end_log_id) { $all_accounted = true; }
 } while (!$all_accounted);
 

--- a/get-log-digest.php
+++ b/get-log-digest.php
@@ -1,0 +1,65 @@
+<?php
+$hasDetailsClause = "details != ''";
+
+if(version_compare(REDCAP_VERSION, '10.8.2', '<')){
+	// This REDCap version does not support functions or comparisons in select log queries.
+	// Just always show the details button on older versions.
+	$hasDetailsClause = 1;
+}
+
+$digestLog = new \Vanderbilt\APISyncExternalModule\DigestLog($module);
+
+$module_id_query = $module->framework->query(
+	"SELECT external_module_id FROM redcap_external_modules WHERE directory_prefix = ?",
+	[$module->PREFIX]
+);
+$this_module_id = $module_id_query->fetch_assoc()['external_module_id'];
+
+$start_log_id = 1;
+$end_log_id = $start_log_id;
+$min_log_id = $start_log_id;
+
+$results = $module->queryLogs("
+	select MAX(log_id) as max, MIN(log_id) as min
+	where external_module_id = ? and project_id = ?
+", [$this_module_id, $module->getProjectId()]);
+
+while($row = $results->fetch_assoc()){
+	$start_log_id = $row['max'];
+	$min_log_id = $row['min'];
+	$end_log_id = $start_log_id - 10;
+}
+
+$message_subtrings = $digestLog::createLikeStatements();
+
+// NOTE: probably don't need EM id or project_id
+// NOTE: $message_subtrings can't be included as a ? parameter
+$all_accounted = false;
+do  {
+	$results = $module->queryLogs("
+	select log_id, timestamp, message, failure, $hasDetailsClause as hasDetails
+	where external_module_id = ? and project_id = ?
+	and log_id >= ? and log_id <= ?
+	and $message_subtrings
+	order by log_id desc
+", [$this_module_id, $module->getProjectId(), $end_log_id, $start_log_id]);
+
+	while($row = $results->fetch_assoc()){
+		$digestLog->parseLogRow($row);
+	}
+
+	$all_accounted = $digestLog->isDone();
+
+	$start_log_id = $end_log_id;
+	$end_log_id = max($end_log_id - 10, $min_log_id);
+	if ($start_log_id == $end_log_id) { $all_accounted = true; }
+} while (!$all_accounted);
+
+$min_url_statuses = $digestLog->getDigest();
+
+?>
+
+
+{
+	"data": <?=json_encode($min_url_statuses, JSON_PRETTY_PRINT)?>
+}

--- a/log_digest.php
+++ b/log_digest.php
@@ -1,0 +1,198 @@
+<script src="https://cdnjs.cloudflare.com/ajax/libs/limonte-sweetalert2/8.11.8/sweetalert2.all.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/gasparesganga-jquery-loading-overlay@2.1.6/dist/loadingoverlay.min.js" integrity="sha384-L2MNADX6uJTVkbDNELTUeRjzdfJToVbpmubYJ2C74pwn8FHtJeXa+3RYkDRX43zQ" crossorigin="anonymous"></script>
+
+<? $module->includeCss("css/pages.css"); ?>
+
+<div id="api-sync-module-wrapper">
+	<?=$module->initializeJavascriptModuleObject()?>
+	<script>
+		ExternalModules.Vanderbilt.APISyncExternalModule.showDetails = function(logId){
+			var width = window.innerWidth - 100;
+			var height = window.innerHeight - 200;
+			$.get(<?=json_encode($module->getUrl('get-log-details.php') . '&log-id=')?> + logId, function(details){
+				var content = '<pre style="max-height: ' + height + 'px">' + details + '</pre>'
+				simpleDialog(content, 'Details', null, width)
+			})
+		}
+
+		ExternalModules.Vanderbilt.APISyncExternalModule.showSyncCancellationDetails = function(){
+			var div = $('#api-sync-module-cancellation-details').clone()
+			div.show()
+
+			var pre = div.find('pre');
+
+			// Replace tabs with spaces for easy copy pasting into the mysql command line interface
+			pre.html(pre.html().replace(/\t/g, '    '))
+
+			ExternalModules.Vanderbilt.APISyncExternalModule.trimPreIndentation(pre[0])
+
+			simpleDialog(div, 'Sync Cancellation', null, 1000)
+		}
+
+		ExternalModules.Vanderbilt.APISyncExternalModule.trimPreIndentation = function(pre){
+			var content = pre.innerHTML
+			var firstNonWhitespaceIndex = content.search(/\S/)
+			var leadingWhitespace = content.substr(0, firstNonWhitespaceIndex)
+			pre.innerHTML = content.replace(new RegExp(leadingWhitespace, 'g'), '');
+		}
+	</script>
+
+
+	<div style="color: #800000;font-size: 16px;font-weight: bold;"><?=$module->getModuleName()?> - Latest Activity </div>
+
+	<table id="api-sync-module-log-entries" class="table table-striped table-bordered"></table>
+
+	<script>
+		Swal = Swal.mixin({
+			buttonsStyling: false,
+			allowOutsideClick: false
+		})
+
+		$(function(){
+			var ajaxRequest = function(args) {
+				var spinnerElement = $('<div class="api-sync-module-spinner"></div>')[0]
+				new Spinner().spin(spinnerElement)
+
+				Swal.fire({
+					title: spinnerElement,
+					text: args.loadingMessage,
+					showConfirmButton: false
+				})
+
+				var startTime = Date.now()
+				$.post(args.url, { redcap_csrf_token: '<?= $module->getCSRFToken() ?>'}, function (response) {
+					var millisPassed = Date.now() - startTime
+					var delay = 2000 - millisPassed
+					if (delay < 0) {
+						delay = 0
+					}
+
+					setTimeout(function () {
+						if (response === 'success') {
+							Swal.fire('', args.successMessage + args.successMessageSuffix)
+						}
+						else {
+							Swal.fire('', 'An error occurred.  Please see the browser console for details.')
+							console.log('API Sync AJAX Response:', response)
+						}
+					}, delay)
+				})
+			}
+		})
+
+		$(function(){
+			$.LoadingOverlay('show') // hide empty table during initial load
+
+			const wrapper = $('#api-sync-module-wrapper')
+			const startInput = wrapper.find('input[name=start]')
+			const endInput = wrapper.find('input[name=end]')
+
+			$.fn.dataTable.ext.errMode = 'throw';
+			var table = $('#api-sync-module-log-entries').DataTable({
+				"pageLength": 10,
+				"processing": true,
+				"ajax": {
+					url: <?=json_encode($module->getUrl('get-log-digest.php'))?>,
+					data: data => {
+						data.start = startInput.val()
+						data.end = endInput.val()
+					},
+					error: function (jqXHR, textStatus, errorThrown) {
+						$.LoadingOverlay('hide')
+
+						Swal.fire({
+							title: 'Error',
+							text: jqXHR.responseText
+						})
+					}
+				},
+				"autoWidth": true,
+				"searching": true,
+				"order": [[ 0, "desc" ]],
+				"columns": [
+					{
+						data: 'timestamp',
+						title: 'Date/Time',
+						width: 125
+					},
+					{
+						data: 'import_source',
+						title: 'Import Source'
+					},
+					{
+						data: 'n_records',
+						title: 'Number of Records Pulled',
+						width: 125
+					},
+					{
+						data: 'status',
+						title: 'Status'
+					},
+					{
+						title: 'Actions',
+						render: function(data, type, row, meta){
+							var html = ''
+							var logId = row.error_log_id
+
+							if(logId){
+								html += "<button onclick='ExternalModules.Vanderbilt.APISyncExternalModule.showDetails(" + logId + ")'>Show Details</button>"
+							}
+
+							// Only allow retrying the last failed import.
+							if(row.failure && meta.row === 1){
+								var form = $('#api-sync-module-wrapper form.retry')
+								form.find('input[name=retry-log-id]').val(logId)
+								form.show()
+							}
+
+							return html
+						}
+					},
+				],
+				"dom": 'Blftip'
+		    }).on( 'draw', function () {
+				var ellipsis = $('.dataTables_paginate .ellipsis')
+				ellipsis.addClass('paginate_button')
+				ellipsis.click(function(e){
+					var jumpToPage = async function(){
+						const response = await Swal.fire({
+							text: 'What page number would like like to jump to?',
+							input: 'text',
+							showCancelButton: true
+						})
+
+						var page = response.value
+
+						var pageCount = table.page.info().pages
+
+						if(isNaN(page) || page < 1 || page > pageCount){
+							Swal.fire('', 'You must enter a page between 1 and ' + pageCount)
+						}
+						else{
+							table.page(page-1).draw('page')
+						}
+					}
+
+					jumpToPage()
+
+					return false
+				})
+		    }).on( 'processing.dt', function(e, settings, processing){
+		    	if(processing){
+					$.LoadingOverlay('show')
+		    	}
+		    	else{
+		    		$.LoadingOverlay('hide')
+		    	}
+		    })
+
+			startInput.change(() => table.ajax.reload())
+			endInput.change(() => table.ajax.reload())
+
+			$.LoadingOverlaySetup({
+				'background': 'rgba(30,30,30,0.7)'
+			})
+		})
+	</script>
+</div>


### PR DESCRIPTION
This PR adds a new project-level page named "API Sync - Latest Activity":

![image](https://github.com/vanderbilt-redcap/api-sync-module/assets/20332546/448c8a1f-e6f6-4042-a0e5-401f19b657b9)


Customer's request:

> the current logging page is pretty good but it’s not easy to figure out the latest status of each site. A table with each site and the datetime, status, and number of records pulled, in the last data pull.

I clarified via email that they indeed want info on the latest import for each url defined in the module configuration.