### PR TITLE
Add time windowing to digest page to reduce load on server

### DIFF
--- a/get-log-digest.php
+++ b/get-log-digest.php
@@ -3,6 +3,9 @@ namespace Vanderbilt\APISyncExternalModule;
 $hasDetailsClause = "details != ''";
 const LOG_WINDOW_SIZE = 100;
 
+$start = $module->requireDateParameter('start', 'Y-m-d');
+$end = $module->requireDateParameter('end', 'Y-m-d');
+
 if(version_compare(REDCAP_VERSION, '10.8.2', '<')){
 	// This REDCap version does not support functions or comparisons in select log queries.
 	// Just always show the details button on older versions.
@@ -24,7 +27,8 @@ $min_log_id = $start_log_id;
 $results = $module->queryLogs("
 	select MAX(log_id) as max, MIN(log_id) as min
 	where external_module_id = ? and project_id = ?
-", [$this_module_id, $module->getProjectId()]);
+	AND timestamp >= ? and timestamp < ?
+", [$this_module_id, $module->getProjectId(), $start, $end]);
 
 while($row = $results->fetch_assoc()){
 	$start_log_id = $row['max'];

--- a/log_digest.php
+++ b/log_digest.php
@@ -41,6 +41,15 @@
 
 	<div style="color: #800000;font-size: 16px;font-weight: bold;"><?=$module->getModuleName()?> - Latest Activity </div>
 
+	<?php
+	$start = (new DateTime())->sub(date_interval_create_from_date_string('7 days'))->format('Y-m-d');
+	$end = (new DateTime())->format('Y-m-d');
+	?>
+
+	<label>Start Date</label><input name='start' type='date' value='<?=$start?>'><br>
+	<label>End Date</label><input name='end' type='date' value='<?=$end?>'><br>
+	<br>
+
 	<table id="api-sync-module-log-entries" class="table table-striped table-bordered"></table>
 
 	<script>


### PR DESCRIPTION
Introduces temporal constraints on the "Latest Activity" page, default is set to 1 week to mirror the log viewer.