### PR TITLE
Include proxy settings in curl options

### DIFF
--- a/APISyncExternalModule.php
+++ b/APISyncExternalModule.php
@@ -1171,6 +1171,8 @@ class APISyncExternalModule extends \ExternalModules\AbstractExternalModule{
 		curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
 		curl_setopt($ch, CURLOPT_FRESH_CONNECT, 1);
 		curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($data, '', '&'));
+		curl_setopt($ch, CURLOPT_PROXY, PROXY_HOSTNAME); // If using a proxy
+		curl_setopt($ch, CURLOPT_PROXYUSERPWD, PROXY_USERNAME_PASSWORD); // If using a proxy
 
 		$tries = 0;
 		$sleepTime = 60;


### PR DESCRIPTION
Including the global variables for proxy settings in similar fashion to core REDCap curl usage. Without these the module is not functional in REDCap instances configured to use a proxy.