### PR TITLE
Fix log digest edge cases

### DIFF
--- a/get-log-digest.php
+++ b/get-log-digest.php
@@ -36,6 +36,12 @@ while($row = $results->fetch_assoc()){
 	$end_log_id = $start_log_id - LOG_WINDOW_SIZE;
 }
 
+// Prevent potential infinite loop if no log entries are found in provided time window
+if (is_null($start_log_id) || is_null($min_log_id)) {
+	echo "No activity found in the provided time window, please expand your search.";
+	exit();
+}
+
 $message_subtrings = $digestLog::createLikeStatements();
 
 // NOTE: probably don't need EM id or project_id

--- a/get-log-digest.php
+++ b/get-log-digest.php
@@ -27,7 +27,7 @@ $min_log_id = $start_log_id;
 $results = $module->queryLogs("
 	select MAX(log_id) as max, MIN(log_id) as min
 	where external_module_id = ? and project_id = ?
-	AND timestamp >= ? and timestamp < ?
+	AND timestamp >= ? and timestamp < DATE_ADD(?, INTERVAL 1 DAY)
 ", [$this_module_id, $module->getProjectId(), $start, $end]);
 
 while($row = $results->fetch_assoc()){


### PR DESCRIPTION
339dc27d38f9f65e408a4e13cb1efe836a869bf2 allows log entries to be inclusive up to the end of the provided "End Date". Prior to this commit, anything that occurred _on_ the provided "End Date" would not be show in the digest.

Before this change:
![image](https://github.com/user-attachments/assets/c482389c-72e4-412b-8282-2ad698732857)


With this change:
![image](https://github.com/user-attachments/assets/77f1b313-118e-4986-ba72-32aa2dbb9e8f)

---

5cd9f787a3a6eaa88efd8b3fc5bc7bd8c1cb01dd prevents an infinite loop from occurring on the log digest page. This was caused by `$start_log_id` and `$min_log_id` being set to `NULL`, causing the `$all_accounted` while loop to never exit because `$start_log_id` and `$end_log_id` were constantly decrementing as negative values.

---

I discovered both of these edge cases by setting up API Sync in a new project and attempting to check the "API Sync - Latest Activity" page.