### PR TITLE
File sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
-
-
 # API Sync
 
 Automates exporting/importing to/from remote REDCap servers via the API.  The Data Dictionaries for the local and remote projects are expected to be either identical or "compatible".  Examples of "compatible" data dictionaries might include the destination having additional fields or dropdown choices that the source doesn't have.  In general, any scenario should work with this module that works without error when manually exporting & importing from one project to another.  Under the hood, the module is essentially automating a full manual CSV export/import, including reporting any errors you would normally receive due to Data Dictionary differences.  Functionality could fairly easily be expanded to support additional scenarios, like automatically syncing the data dictionary as well, or specifying an include/exclude list of fields to sync instead of all fields.
-	
+
 This module stores API keys for remote systems in the module settings table in local REDCap database.  The same level of security applies as would apply to PHI or any other sensitive data stored in the local REDCap project.  This means users with design rights on the project, REDCap system administrators, server administrators, and/or database administrators would potentially have access to those API keys (as they would any other data on the local system).
 
 ## Form and Event Translations
+
 Version 1.7.0 of the API Sync module introduces the form and event translations feature. This allows administrators to set translations for projects so that imported or exported data will have their form/event names translated upon import/export.
 
 These translations are editable via the "Configure Translations" module page under the External Modules header in the REDCap project's sidebar.
+
 ### Configuring Translations for Import Projects
+
 The first column of a configured form/event table should contain the names of the form/event names used in the destination project -- that is, the project that data is being imported to.
 
 The following columns should contain form/event names used in source projects. When importing data, the module tries to find form/event names listed in the source columns. If a match is found, the name in the data is translated to the name in the first column.
@@ -20,7 +21,9 @@ An example project configured with the following table would convert the form na
 ![Configuring import translations](/readme/import_forms.PNG)
 
 Users can select rows by clicking table cells or select columns by clicking the column name. Selected rows and columns can be removed by clicking '- Remove'. Additional rows and columns can be added by clicking '+ Row' or '+ Column' respectively. The 'Export' and 'Import' buttons export or import CSV.
+
 ### Configuring Translations for Export Projects
+
 Export tables are similar to import tables except they can contain only two columns. The first being the local form/event name and the second column containing the form or event name the module will translate the local form/event name to upon export.
 
 For this reason, there is no '+ Column' button and columns cannot be removed.
@@ -28,17 +31,22 @@ For this reason, there is no '+ Column' button and columns cannot be removed.
 In the following example table, the module is configured to convert the 'First Form' form name to 'Their Form Name' and 'Other Form' to 'Their Other Form' before exporting data.
 
 ![Configuring export translations](/readme/export_forms.PNG)
+
 ### Note: Form and Event Names in REDCap
+
 REDCap forms and events have two names. A display name and a unique name. The unique name is usually not shown to users but it's how REDCap refers to forms and events internally. You may use either in the 'Configure Translations' tables -- the module can usually determine the correct unique name for a given display name.
 
 The module won't be able to determine the unique name in the following cases:
 
- 1. The display name contains only non-Latin characters. 
+1. The display name contains only non-Latin characters.
 
-	In this case, REDCap will generate a unique form name using random characters. The module won't be able to guess the unique form name in this case.
+   In this case, REDCap will generate a unique form name using random characters. The module won't be able to guess the unique form name in this case.
+2. The remote instance of REDCap contains multiple forms/events with the same display name.
 
- 2. The remote instance of REDCap contains multiple forms/events with the same display name.
-
-	In this case, REDCap will append some random characters to make the unique name unique for that form/event.
+   In this case, REDCap will append some random characters to make the unique name unique for that form/event.
 
 Using the display name in the above cases will cause imports/exports to fail. The workaround is to determine the unique names for the forms/events and use those instead. You can determine these unique names, for instance, by exporting the raw data as CSV and finding the names within the exported file.
+
+### File Sync
+
+This module will handle files in an import or export if the configuration setting to import/export files is checked in the configuration for each given project. Note that files are only transferred **when a filename as changed**. If a filename stays the same, the sync module will assume that the file has stayed the same. When the source file is deleted, the corresponding file on the destination will be deleted. To delete files, the user with the API token must have Delete Record user rights.

--- a/config.json
+++ b/config.json
@@ -11,7 +11,8 @@
 		}
 	],
 	"compatibility": {
-		"redcap-version-min": "11.2.0"
+		"php-version-min": "7.3.0",
+		"redcap-version-min": "12.5.2"
 	},
 	"permissions": [],
 	"project-settings": [
@@ -133,6 +134,11 @@
 									"value": "exclude"
 								}
 							]
+						},
+						{
+							"key": "export-files",
+							"name": "Check to export files <strong>only when the filename has changed</strong>. When exported, any files on the server will be overwritten by the new files. Exporting files can significantly increase the time required to sync a project. <strong>The holder of the API token must have Delete Record privileges on the remote server.</strong>",
+							"type": "checkbox"
 						},
 						{
 							"key": "export-field-list",
@@ -280,6 +286,11 @@
 							"name": "Field List",
 							"type": "field-list",
 							"repeatable": true
+						},
+												{
+							"key": "import-files",
+							"name": "Check to import files <strong>only when the filename has changed</strong>. Files that you have saved <strong>will be replaced</strong> by any downloaded files. Importing files can significantly increase the amount of time required to sync a project.",
+							"type": "checkbox"
 						},
 						{
 							"key": "form-translations",


### PR DESCRIPTION
# Pre-flight Checklist
- [x] Are all the features in this PR tested? 
- [x] Have other features this PR touches also been tested?
- [x] Has the code been formatted for consistency and readability?
- [x] Did you also update related documentation and tooling, such as .readme or tests?

# Overview
This new feature for the API Sync module facilitates the synching of files if a configuration setting is checked. It handles imports and exports as described in the `README.md`. File deletions are made if the source project is empty. Logging messages are made if file transmission is successful.

# Context
This PR is necessitated by an Edge for Scholars project that requires a large amount of files to be synched on a dev server.

# Screenshots
To enable or disable, check the box in the module's configuration that says:
- `export-files`: Check to export files only when the filename has changed. When exported, any files on the server will be overwritten by the new files. Exporting files can significantly increase the time required to sync a project. The holder of the API token must have Delete Record privileges on the remote server.
- `import-files`: Check to import files only when the filename has changed. Files that you have saved will be replaced by any downloaded files. Importing files can significantly increase the amount of time required to sync a project.