### PR TITLE
Fix skipped record issue for rvp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /vendor/
 composer*
 /.vscode/launch.json
+/.php-cs-fixer.cache

--- a/APISyncExternalModule.php
+++ b/APISyncExternalModule.php
@@ -177,6 +177,11 @@ class APISyncExternalModule extends \ExternalModules\AbstractExternalModule
 		);
 
 		$weekOldId = $result->fetch_assoc()['log_event_id'];
+		/**
+		 * We subtract one from $weekOldId because the return value from this function should be (or simulate)
+		 * the last ID that was previously synced. Subtracting one ensures that $weekOldId itself is processed.
+		 */
+		$weekOldId--;
 		$lastExportedId = $this->getProjectSetting('last-exported-log-id');
 
 		/**

--- a/APISyncExternalModule.php
+++ b/APISyncExternalModule.php
@@ -24,7 +24,11 @@ class APISyncExternalModule extends \ExternalModules\AbstractExternalModule
 	public const EXPORT_CANCELLED_MESSAGE = 'Export cancelled.';
 
 	public const DATA_VALUES_MAX_LENGTH = (2 ^ 16) - 1;
-	public const MAX_LOG_QUERY_PERIOD = 7;
+	/**
+	 * We semi-arbitrarily changed this from 7 to 8 days to make sure logs don't get
+	 * skipped on syncs that only run once a week (per the 'export-weekday' setting).
+	 */
+	public const MAX_LOG_QUERY_PERIOD = 8;
 
 	private $settingPrefix;
 	private $cachedSettings;


### PR DESCRIPTION
# Pre-flight Checklist
- [x] Have all lines in this PR been reviewed & optimized by a human with appropriate coding skills? 
- [x] Are all the features in this PR tested by a human? 
- [x] Have other features this PR touches also been tested by a human?
- [x] Has the code been formatted for consistency and readability?
- N/A - Did you also update related documentation and tooling, such as .readme or tests?

# Overview
The [REDRSVC Committee Change Log v2.0 project](https://redcap.vumc.org/redcap_v17.2.1/index.php?pid=197037) was seeing an intermittent issue where the first record of a batch was getting skipped if it the `redcap_log_event` row representing its addition was the first within the past week.  This should resolve it.